### PR TITLE
Xmake3 0 modules jobpool

### DIFF
--- a/tests/projects/c++/modules/include-dirs/include/foo.h
+++ b/tests/projects/c++/modules/include-dirs/include/foo.h
@@ -1,0 +1,1 @@
+inline int foo() { return 0; }

--- a/tests/projects/c++/modules/include-dirs/src/hello.mpp
+++ b/tests/projects/c++/modules/include-dirs/src/hello.mpp
@@ -1,0 +1,9 @@
+module;
+
+#include "foo.h"
+
+export module bar;
+
+export int bar() {
+  return foo();
+}

--- a/tests/projects/c++/modules/include-dirs/src/main.cpp
+++ b/tests/projects/c++/modules/include-dirs/src/main.cpp
@@ -1,0 +1,5 @@
+import bar;
+
+int main() {
+  return bar();
+}

--- a/tests/projects/c++/modules/include-dirs/test.lua
+++ b/tests/projects/c++/modules/include-dirs/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_base")

--- a/tests/projects/c++/modules/include-dirs/xmake.lua
+++ b/tests/projects/c++/modules/include-dirs/xmake.lua
@@ -1,0 +1,17 @@
+add_rules("mode.debug", "mode.release")
+
+rule("include")
+    before_config(function (target)
+        target:add("includedirs", "$(projectdir)/include")
+    end)
+
+target("src1")
+    set_kind("static")
+    add_rules("include")
+    add_files("src/*.mpp", {public = true})
+    add_defines("A")
+
+target("src2")
+    set_kind("binary")
+    add_deps("src1")
+    add_files("src/*.cpp")

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/bar.cpp
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/bar.cpp
@@ -1,0 +1,5 @@
+#include <a.hpp>
+
+const char *hello() {
+    return "Hello world";
+}

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/bar.mpp
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/bar.mpp
@@ -1,0 +1,12 @@
+module;
+
+#include <a.hpp>
+
+export module bar;
+
+export namespace bar {
+const char *hello() {
+     return ::hello();
+}
+}
+

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/include/a.hpp
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/include/a.hpp
@@ -1,0 +1,6 @@
+#ifndef A_HPP
+#define A_HPP
+
+[[gnu::visibility("default")]] const char *hello();
+
+#endif

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/src/xmake.lua
@@ -1,0 +1,9 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("bar")
+    set_kind("static")
+    add_headerfiles("include/(**.hpp)")
+    add_includedirs("include")
+    add_files("*.cpp")
+    add_files("*.mpp", { public = true })

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar/xmake.lua
@@ -1,0 +1,6 @@
+package("bar")
+    set_sourcedir(path.join(os.scriptdir(), "src"))
+
+    on_install(function(package)
+        import("package.tools.xmake").install(package, {})
+    end)

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar2/src/bar.mpp
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar2/src/bar.mpp
@@ -1,0 +1,8 @@
+export module bar2;
+
+export namespace bar {
+    const char *hello2() {
+        return "Hello world";
+    }
+}
+

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar2/src/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar2/src/xmake.lua
@@ -1,0 +1,6 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("bar2")
+    set_kind("moduleonly")
+    add_files("*.mpp")

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar2/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/b/bar2/xmake.lua
@@ -1,0 +1,7 @@
+package("bar2")
+    set_kind("library", {moduleonly = true})
+    set_sourcedir(path.join(os.scriptdir(), "src"))
+
+    on_install(function(package)
+        import("package.tools.xmake").install(package, {})
+    end)

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/src/foo.cpp
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/src/foo.cpp
@@ -1,0 +1,6 @@
+module foo;
+
+namespace foo {
+    void say(const char *msg) {
+    }
+}

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/src/foo.mpp
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/src/foo.mpp
@@ -1,0 +1,7 @@
+export module foo;
+
+export namespace foo {
+  #ifdef FOO_EXPORT
+    void say(const char *);
+  #endif
+}

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/src/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/src/xmake.lua
@@ -1,0 +1,7 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("foo")
+    set_kind("static")
+    add_files("*.cpp")
+    add_files("*.mpp", {defines = "FOO_EXPORT", public = true})

--- a/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/my-repo/packages/f/foo/xmake.lua
@@ -1,0 +1,6 @@
+package("foo")
+    set_sourcedir(path.join(os.scriptdir(), "src"))
+
+    on_install(function(package)
+        import("package.tools.xmake").install(package, {})
+    end)

--- a/tests/projects/c++/modules/packages-subtarget/src/main.cpp
+++ b/tests/projects/c++/modules/packages-subtarget/src/main.cpp
@@ -1,0 +1,8 @@
+import foobar;
+import bar2;
+
+int main() {
+    foo::say(bar::hello());
+    foo::say(bar::hello2());
+    return 0;
+}

--- a/tests/projects/c++/modules/packages-subtarget/src/mod.mpp
+++ b/tests/projects/c++/modules/packages-subtarget/src/mod.mpp
@@ -1,0 +1,4 @@
+export module foobar;
+
+export import foo;
+export import bar;

--- a/tests/projects/c++/modules/packages-subtarget/test.lua
+++ b/tests/projects/c++/modules/packages-subtarget/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_headerunits")

--- a/tests/projects/c++/modules/packages-subtarget/xmake.lua
+++ b/tests/projects/c++/modules/packages-subtarget/xmake.lua
@@ -1,0 +1,17 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++2b")
+
+add_repositories("my-repo my-repo")
+add_requires("foo", "bar", "bar2")
+
+target("dep")
+    set_kind("static")
+    add_packages("foo", "bar")
+    add_files("src/*.mpp", {public = true})
+
+target("packages")
+    set_kind("binary")
+    add_files("src/*.cpp")
+    add_deps("dep")
+    add_packages("foo", "bar", "bar2")
+    set_policy("build.c++.modules", true)

--- a/tests/projects/c++/modules/phony/src/hello.mpp
+++ b/tests/projects/c++/modules/phony/src/hello.mpp
@@ -1,0 +1,27 @@
+module;
+
+#include <iostream>
+
+export module hello;
+
+export namespace hello {
+    class say {
+    public:
+        say(int data);
+        void hello();
+    private:
+        int data_;
+    };
+}
+
+module :private;
+
+using namespace std;
+namespace hello {
+    say::say(int data) : data_(data) {
+
+    }
+    void say::hello() {
+        cout << "hello, say class: " << data_ << endl;
+    }
+}

--- a/tests/projects/c++/modules/phony/src/main.cpp
+++ b/tests/projects/c++/modules/phony/src/main.cpp
@@ -1,0 +1,7 @@
+import hello;
+
+int main() {
+    hello::say s(sizeof(hello::say));
+    s.hello();
+    return 0;
+}

--- a/tests/projects/c++/modules/phony/test.lua
+++ b/tests/projects/c++/modules/phony/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_base")

--- a/tests/projects/c++/modules/phony/xmake.lua
+++ b/tests/projects/c++/modules/phony/xmake.lua
@@ -1,0 +1,12 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("test-phony")
+    set_kind("phony")
+    add_files("src/*.mpp", {public = true})
+
+target("class")
+    set_kind("binary")
+    add_files("src/*.cpp")
+    add_deps("test-phony")
+

--- a/tests/projects/c++/modules/phony2/include/foo.h
+++ b/tests/projects/c++/modules/phony2/include/foo.h
@@ -1,0 +1,1 @@
+inline int foo() { return 5; }

--- a/tests/projects/c++/modules/phony2/src/hello.mpp
+++ b/tests/projects/c++/modules/phony2/src/hello.mpp
@@ -1,0 +1,28 @@
+module;
+
+#include <iostream>
+#include <foo.h>
+
+export module hello;
+
+export namespace hello {
+    class say {
+    public:
+        say(int data);
+        void hello();
+    private:
+        int data_;
+    };
+}
+
+module :private;
+
+using namespace std;
+namespace hello {
+    say::say(int data) : data_(data) {
+
+    }
+    void say::hello() {
+        cout << "hello, say class: " << data_ << "and" << foo() << endl;
+    }
+}

--- a/tests/projects/c++/modules/phony2/src/main.cpp
+++ b/tests/projects/c++/modules/phony2/src/main.cpp
@@ -1,0 +1,7 @@
+import hello;
+
+int main() {
+    hello::say s(sizeof(hello::say));
+    s.hello();
+    return 0;
+}

--- a/tests/projects/c++/modules/phony2/test.lua
+++ b/tests/projects/c++/modules/phony2/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_base")

--- a/tests/projects/c++/modules/phony2/xmake.lua
+++ b/tests/projects/c++/modules/phony2/xmake.lua
@@ -1,0 +1,17 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("test")
+    set_kind("static")
+    add_includedirs("include")
+    add_files("src/*.mpp", {public = true})
+
+target("test-phony")
+    set_kind("phony")
+    add_deps("test")
+
+target("class")
+    set_kind("binary")
+    add_files("src/*.cpp")
+    add_deps("test-phony")
+

--- a/tests/projects/c++/modules/test_dependency_scanner.lua
+++ b/tests/projects/c++/modules/test_dependency_scanner.lua
@@ -3,7 +3,7 @@ import("core.base.semver")
 import("utils.ci.is_running", {alias = "ci_is_running"})
 
 function _build()
-    os.run("xmake f --foo=n")
+    os.run("xmake f --foo=n --policies=build.c++.modules.std:n")
     local outdata
     if ci_is_running() then
         outdata = os.iorun("xmake -rvD")

--- a/tests/projects/c++/modules/test_headerunits.lua
+++ b/tests/projects/c++/modules/test_headerunits.lua
@@ -22,12 +22,12 @@ function main(t)
         local clang = find_tool("clang", {version = true})
         if clang and clang.version and semver.compare(clang.version, "15.0") >= 0 then
             -- clang headerunit are bugged
-            -- os.exec("xmake f --toolchain=clang -c --yes --policies=build.c++.modules.std:n,build.c++.clang.fallbackscanner")
+            -- os.exec("xmake f --toolchain=clang -c --yes --policies=build.c++.modules.std:n,build.c++.modules.fallbackscanner")
             -- _build()
             -- if semver.compare(clang.version, "17.0") >= 0 then
             --     os.exec("xmake clean -a")
             --     -- clang-scan-deps dependency detection doesn't support header units atm
-            --     os.exec("xmake f --toolchain=clang --runtimes=c++_shared -c --yes --policies=build.c++.modules.std:n,build.c++.clang.fallbackscanner")
+            --     os.exec("xmake f --toolchain=clang --runtimes=c++_shared -c --yes --policies=build.c++.modules.std:n,build.c++.modules.fallbackscanner")
             --     _build()
             -- end
         end
@@ -40,14 +40,14 @@ function main(t)
         end
     elseif is_subhost("msys") then
         -- on windows, mingw modulemapper doesn't handle headeunit path correctly, but it's working with mingw on macOS / Linux
-        -- os.exec("xmake f -c -p mingw --yes --policies=build.c++.modules.std:n,build.c++.gcc.fallbackscanner")
+        -- os.exec("xmake f -c -p mingw --yes --policies=build.c++.modules.std:n,build.c++.modules.fallbackscanner")
         -- _build()
     elseif is_host("linux") then
         local gcc = find_tool("gcc", {version = true})
         if gcc and gcc.version and semver.compare(gcc.version, "11.0") >= 0 and
             os.arch() ~= "arm64" then -- gcc/arm64: internal compiler error: in core_vals, at cp/module.cc:6108
             -- gcc dependency detection doesn't support header units atm
-            os.exec("xmake f -c --yes --policies=build.c++.modules.std:n,build.c++.gcc.fallbackscanner")
+            os.exec("xmake f -c --yes --policies=build.c++.modules.std:n,build.c++.modules.fallbackscanner")
             _build()
         end
         local clang = find_tool("clang", {version = true})
@@ -55,14 +55,14 @@ function main(t)
             if semver.compare(clang.version, "19.0") >= 0 then
                 os.exec("xmake clean -a")
                 -- clang-scan-deps dependency detection doesn't support header units atm
-                os.exec("xmake f --toolchain=clang -c --yes --policies=build.c++.modules.std:n,build.c++.clang.fallbackscanner")
+                os.exec("xmake f --toolchain=clang -c --yes --policies=build.c++.modules.std:n,build.c++.modules.fallbackscanner")
                 _build()
             end
             -- libc++ headerunit are bugged
             -- if semver.compare(clang.version, "17.0") >= 0 then
             --     os.exec("xmake clean -a")
             --     -- clang-scan-deps dependency detection doesn't support header units atm
-            --     os.exec("xmake f --toolchain=clang --runtimes=c++_shared -c --yes --policies=build.c++.modules.std:n,build.c++.clang.fallbackscanner")
+            --     os.exec("xmake f --toolchain=clang --runtimes=c++_shared -c --yes --policies=build.c++.modules.std:n,build.c++.modules.fallbackscanner")
             --     _build()
             -- end
         end

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -72,26 +72,38 @@ function policy.policies()
             ["build.rpath"]                       = {description = "Enable build rpath.", default = true, type = "boolean"},
             -- Enable C++ modules for C++ building, even if no .mpp is involved in the compilation
             ["build.c++.modules"]                 = {description = "Enable C++ modules for C++ building.", type = "boolean"},
+            -- Enable two phase compilation for C++ modules if supported by the compiler
+            ["build.c++.modules.two_phases"]      = {description = "Enable two phase compilation if supported.", default = true, type = "boolean"},
             -- Enable std module
             ["build.c++.modules.std"]             = {description = "Enable std modules.", default = true, type = "boolean"},
             -- Enable unreferenced and non-public named module culling
             ["build.c++.modules.culling"]         = {description = "Enable unrefereced and non-public named module culling.", default = true, type = "boolean"},
-            -- Try to reuse compiled module bmi file if targets flags permit it
-            ["build.c++.modules.tryreuse"]        = {description = "Try to reuse compiled module if possible.", default = true, type = "boolean"},
-            -- Enable module taking defines acbount for bmi reuse discrimination
+            -- Always reuse compiled module bmi file
+            ["build.c++.modules.reuse"]           = {description = "Reuse compiled module artifacts if possible.", default = true, type = "boolean"},
+            ["build.c++.modules.tryreuse"]        = {description = "Try to reuse compiled module if possible. (deprecated)", default = false, type = "boolean"},
+            -- Disabled flag check when reusing modules
+            ["build.c++.modules.reuse.nocheck"]   = {description = "Disable flag compatibility check when reusing modules.", default = false, type = "boolean"},
+            -- If target will not reuse modules from target deps if defines are different
+            ["build.c++.modules.reuse.strict"]          = {description = "Enable strict defines comparison when trying to reuse module.", default = false, type = "boolean"},
             ["build.c++.modules.tryreuse.discriminate_on_defines"] = {description = "Enable defines module reuse discrimination.", default = false, type = "boolean"},
+            -- Force C++ modules fallback dependency scanner for all compilers
+            ["build.c++.modules.fallbackscanner"]       = {description = "Force fallback module dependency scanner.", default = false, type = "boolean"},
             -- Force C++ modules fallback dependency scanner for clang
-            ["build.c++.clang.fallbackscanner"]   = {description = "Force clang fallback module dependency scanner.", default = false, type = "boolean"},
+            ["build.c++.modules.clang.fallbackscanner"] = {description = "Force clang fallback module dependency scanner.", default = false, type = "boolean"},
+            ["build.c++.clang.fallbackscanner"]         = {description = "Force clang fallback module dependency scanner. (deprecated)", default = false, type = "boolean"},
             -- Force C++ modules fallback dependency scanner for msvc
-            ["build.c++.msvc.fallbackscanner"]    = {description = "Force msvc fallback module dependency scanner.", default = false, type = "boolean"},
-            -- Set the default vs runtime, e.g. MT, MD
-            ["build.c++.msvc.runtime"]            = {description = "Set the default vs runtime.", type = "string", values = {"MT", "MD"}},
+            ["build.c++.modules.msvc.fallbackscanner"]  = {description = "Force msvc fallback module dependency scanner.", default = false, type = "boolean"},
+            ["build.c++.msvc.fallbackscanner"]          = {description = "Force msvc fallback module dependency scanner. (deprecated)", default = false, type = "boolean"},
             -- Force C++ modules fallback dependency scanner for gcc
-            ["build.c++.gcc.fallbackscanner"]     = {description = "Force gcc fallback module dependency scanner.", default = false, type = "boolean"},
+            ["build.c++.modules.gcc.fallbackscanner"]   = {description = "Force gcc fallback module dependency scanner.", default = false, type = "boolean"},
+            ["build.c++.gcc.fallbackscanner"]           = {description = "Force gcc fallback module dependency scanner. (deprecated)", default = false, type = "boolean"},
             -- Force to enable new cxx11 abi in C++ modules for gcc
             -- If in the future, gcc can support it well, we'll turn it on by default
             -- https://github.com/xmake-io/xmake/issues/3855
-            ["build.c++.gcc.modules.cxx11abi"]    = {description = "Force to enable new cxx11 abi in C++ modules for gcc.", type = "boolean"},
+            ["build.c++.modules.gcc.cxx11abi"]    = {description = "Force to enable new cxx11 abi in C++ modules for gcc.", type = "boolean"},
+            ["build.c++.gcc.modules.cxx11abi"]    = {description = "Force to enable new cxx11 abi in C++ modules for gcc. (deprecated)", type = "boolean", default = false},
+            -- Set the default vs runtime, e.g. MT, MD
+            ["build.c++.msvc.runtime"]            = {description = "Set the default vs runtime.", type = "string", values = {"MT", "MD"}},
             -- Enable cuda device link
             ["build.cuda.devlink"]                = {description = "Enable Cuda devlink.", type = "boolean"},
             -- Enable build jobgraph

--- a/xmake/core/tool/toolchain.lua
+++ b/xmake/core/tool/toolchain.lua
@@ -288,12 +288,18 @@ function _instance:configs_save()
 end
 
 -- do check, we only check it once for all architectures
-function _instance:check()
-    local checked = self:config("__checked")
+function _instance:check(opt)
+
+    opt = opt or {}
+    local checked_config = "__checked"
+    if opt.ignore_sdk then
+        checked_config = checked_config .. "_sdk_ignored"
+    end
+    local checked = self:config(checked_config)
     if checked == nil then
         local on_check = self:_on_check()
         if on_check then
-            local ok, results_or_errors = sandbox.load(on_check, self)
+            local ok, results_or_errors = sandbox.load(on_check, self, opt)
             if ok then
                 checked = results_or_errors
             else
@@ -304,7 +310,7 @@ function _instance:check()
         end
         -- we need to persist this state
         checked = checked or false
-        self:config_set("__checked", checked)
+        self:config_set(checked_config, checked)
         self:configs_save()
     end
     return checked

--- a/xmake/languages/c++/xmake.lua
+++ b/xmake/languages/c++/xmake.lua
@@ -32,7 +32,8 @@ language("c++")
 
     set_nameflags {
         object = {
-            "config.includedirs"
+            "target.runtimes"
+        ,   "config.includedirs"
         ,   "config.frameworkdirs"
         ,   "config.frameworks"
         ,   "target.runtimes"

--- a/xmake/languages/c/xmake.lua
+++ b/xmake/languages/c/xmake.lua
@@ -32,7 +32,8 @@ language("c")
 
     set_nameflags {
         object = {
-            "config.includedirs"
+            "target.runtimes"
+        ,   "config.includedirs"
         ,   "config.frameworkdirs"
         ,   "config.frameworks"
         ,   "target.runtimes"

--- a/xmake/modules/core/project/depend.lua
+++ b/xmake/modules/core/project/depend.lua
@@ -70,8 +70,6 @@ end
 
 -- show diagnosis info?
 function _is_show_diagnosis_info()
-    return true
-    --[[
     local show = _g.is_show_diagnosis_info
     if show == nil then
         if project.policy("diagnosis.check_build_deps") then
@@ -81,7 +79,7 @@ function _is_show_diagnosis_info()
         end
         _g.is_show_diagnosis_info = show
     end
-    return show]]
+    return show
 end
 
 -- save dependent info to file

--- a/xmake/plugins/project/main.lua
+++ b/xmake/plugins/project/main.lua
@@ -22,6 +22,7 @@
 import("core.base.option")
 import("core.base.task")
 import("core.project.config")
+import("core.project.project")
 import("make.makefile")
 import("make.xmakefile")
 import("cmake.cmakelists")
@@ -87,6 +88,11 @@ function main()
 
     -- config it first
     task.run("config")
+
+    -- make targets aware that project generator is running
+    for _, target in pairs(project.targets()) do
+        target:data_set("in_project_generator", true)
+    end
 
     -- post statistics
     statistics.post()

--- a/xmake/rules/c++/modules/builder.lua
+++ b/xmake/rules/c++/modules/builder.lua
@@ -15,245 +15,274 @@
 -- Copyright (C) 2015-present, TBOOX Open Source Group.
 --
 -- @author      ruki, Arthapz
--- @file        common.lua
+-- @file        builder.lua
 --
 
 -- imports
 import("core.base.json")
+import("core.base.bytes")
 import("core.base.option")
 import("core.base.hashset")
 import("async.runjobs")
 import("private.async.buildjobs")
+import("private.action.clean.remove_files")
 import("core.tool.compiler")
 import("core.project.config")
 import("core.project.depend")
 import("utils.progress")
+import("stlheaders")
 import("support")
 import("scanner")
+import("mapper")
 
--- build target modules
-function _build_modules(target, sourcebatch, modules, opt)
-    local objectfiles = sourcebatch.objectfiles
-    for _, objectfile in ipairs(objectfiles) do
-        local module = modules[objectfile]
-        if not module then
-            goto continue
-        end
-
-        local name, _, cppfile = support.get_provided_module(module)
-        cppfile = cppfile or module.cppfile
-
-        local deps = {}
-        for name, req in pairs(module.requires or {}) do
-            -- we need to use the full path as dep name if requre item is headerunit
-            local dep = name
-            if req.method:startswith("include-") and req.path then
-                dep = req.path
-            end
-            dep = path.normalize(dep)
-            local depname = target:fullname() .. "/module/" .. dep
-            table.insert(deps, depname)
-        end
-        opt.build_module(deps, module, name, objectfile, cppfile)
-
-        ::continue::
-    end
-end
-
--- build target headerunits
-function _build_headerunits(target, headerunits, opt)
-    local outputdir = support.headerunits_cachedir(target, {mkdir = true})
-    if opt.stl_headerunit then
-        outputdir = path.join(outputdir, "stl")
-    end
-
-    for _, headerunit in ipairs(headerunits) do
-        local outputdir = outputdir
-        if opt.stl_headerunit and headerunit.name:startswith("experimental/") then
-            outputdir = path.join(outputdir, "experimental")
-        end
-        local bmifile = path.join(outputdir, path.filename(headerunit.name) .. support.get_bmi_extension(target))
-        local key = path.normalize(headerunit.path)
-        local build = should_build(target, headerunit.path, bmifile, {key = key, headerunit = true})
-        if build then
-            mark_build(target, key)
-        end
-        opt.build_headerunit(headerunit, key, bmifile, outputdir, build)
-    end
-end
-
--- check if flags are compatible for module reuse
-function _are_flags_compatible(target, other, cppfile)
-    local compinst1 = target:compiler("cxx")
-    local flags1 = compinst1:compflags({sourcefile = cppfile, target = target})
-
-    local compinst2 = other:compiler("cxx")
-    local flags2 = compinst2:compflags({sourcefile = cppfile, target = other})
-
-    -- strip unrelevent flags
-    flags1 = support.strip_flags(target, flags1)
-    flags2 = support.strip_flags(target, flags2)
-
-    if #flags1 ~= #flags2 then
-        return false
-    end
-
-    table.sort(flags1)
-    table.sort(flags2)
-
-    for i = 1, #flags1 do
-        if flags1[i] ~= flags2[i] then
-            return false
-        end
-    end
-    return true
-end
-
--- try to reuse modules from other target
-function _try_reuse_modules(target, modules)
-    for _, module in pairs(modules) do
-        local name, provide, cppfile = support.get_provided_module(module)
-        if not provide then
-            goto continue
-        end
-
-        cppfile = cppfile or module.cppfile
-
-        local fileconfig = target:fileconfig(cppfile)
-        local public = fileconfig and (fileconfig.public or fileconfig.external)
-        if not public then
-            goto continue
-        end
-
-        for _, dep in ipairs(target:orderdeps()) do
-            if not _are_flags_compatible(target, dep, cppfile) then
-                goto nextdep
-            end
-            local mapped = get_from_target_mapper(dep, name)
-            if mapped then
-                support.memcache():set2(target:fullname() .. name, "reuse", true)
-                add_module_to_target_mapper(target, mapped.name, mapped.sourcefile, mapped.bmi, table.join(mapped.opt or {}, {target = dep}))
-                break
-            end
-            ::nextdep::
-        end
-
-        ::continue::
-    end
-    return modules
-end
-
--- should we build this module or headerunit ?
-function should_build(target, sourcefile, bmifile, opt)
-    opt = opt or {}
-    local objectfile = opt.objectfile
-    local compinst = compiler.load("cxx", {target = target})
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local dependfile = target:dependfile(bmifile or objectfile)
-    local dependinfo = target:is_rebuilt() and {} or (depend.load(dependfile) or {})
-    local depvalues = {compinst:program(), compflags}
-
-    -- force rebuild a module if any of its module dependency is rebuilt
-    local requires = opt.requires
-    if requires then
-        for required, _ in table.orderpairs(requires) do
-            local m = get_from_target_mapper(target, required)
-            if m then
-                local rebuild = (m.opt and m.opt.target) and support.memcache():get2("should_build_in_" .. m.opt.target:fullname(), m.key)
-                                                         or support.memcache():get2("should_build_in_" .. target:fullname(), m.key)
-                if rebuild then
-                    dependinfo.files = {}
-                    table.insert(dependinfo.files, sourcefile)
-                    dependinfo.values = depvalues
-                    return true, dependinfo
-                end
-            end
-        end
-    end
-
-    -- reused
-    if opt.name then
-        local m = get_from_target_mapper(target, opt.name)
-        if m and m.opt and m.opt.target then
-            local rebuild = support.memcache():get2("should_build_in_" .. m.opt.target:fullname(), m.key)
-            if rebuild then
-                dependinfo.files = {}
-                table.insert(dependinfo.files, sourcefile)
-                dependinfo.values = depvalues
-            end
-            return rebuild, dependinfo
-        end
-    end
-
-    -- need build this object?
-    local dryrun = option.get("dry-run")
-    local lastmtime = os.isfile(bmifile or objectfile) and os.mtime(dependfile) or 0
-    if dryrun or depend.is_changed(dependinfo, {lastmtime = lastmtime, values = depvalues}) then
-        dependinfo.files = {}
-        table.insert(dependinfo.files, sourcefile)
-        dependinfo.values = depvalues
-        return true, dependinfo
-    end
-    return false
+function _builder(target)
+    return support.import_implementation_of(target, "builder")
 end
 
 -- generate meta module informations for package / other buildsystems import
 --
 -- e.g
 -- {
---      "defines": ["FOO=BAR"]
+--      "flags": ["--std=c++23"]
 --      "imports": ["std", "bar"]
 --      "name": "foo"
 --      "file": "foo.cppm"
 -- }
-function _generate_meta_module_info(target, name, sourcefile, requires)
-    local modulehash = support.get_modulehash(target, sourcefile)
-    local module_metadata = {name = name, file = path.join(modulehash, path.filename(sourcefile))}
+function _generate_meta_module_info(target, module)
 
-    -- add definitions
-    module_metadata.defines = _builder(target).get_module_required_defines(target, sourcefile)
+    local fileconfig = target:fileconfig(module.sourcefile)
+    local defines = table.join(target:get("defines") or {}, (fileconfig and fileconfig.defines) and fileconfig.defines or {})
+    local undefines = table.join(target:get("undefines") or {}, (fileconfig and fileconfig.undefines) and fileconfig.undefines or {})
+    local modulehash = support.get_modulehash(module.sourcefile)
+    local module_metadata = {name = module.name, file = path.join(modulehash, path.filename(module.sourcefile)), defines = defines, undefines = undefines}
 
     -- add imports
-    if requires then
-        for _name, _ in table.orderpairs(requires) do
-            module_metadata.imports = module_metadata.imports or {}
-            table.append(module_metadata.imports, _name)
-        end
+    for name, _ in table.orderpairs(module.deps) do
+        module_metadata.imports = module_metadata.imports or {}
+        table.append(module_metadata.imports, name)
     end
     return module_metadata
 end
 
-function _target_module_map_cachekey(target)
-    local mode = config.mode()
-    return target:fullname() .. "module_mapper" .. (mode or "")
+function _get_module_buildgroup_for(target, type)
+    return target:fullname() .. "/modules/build/" .. type
 end
 
-function _is_duplicated_headerunit(target, key)
-    local _, mapper_keys = get_target_module_mapper(target)
-    return mapper_keys[key]
+function _get_module_buildfilejob_for(target, sourcefile, type)
+    return _get_module_buildgroup_for(target, type) .. "/" .. sourcefile
 end
 
-function _builder(target)
-    local cachekey = tostring(target)
-    local builder = support.memcache():get2("builder", cachekey)
-    if builder == nil then
-        if target:has_tool("cxx", "clang", "clangxx", "clang_cl") then
-            builder = import("clang.builder", {anonymous = true})
-        elseif target:has_tool("cxx", "gcc", "gxx") then
-            builder = import("gcc.builder", {anonymous = true})
-        elseif target:has_tool("cxx", "cl") then
-            builder = import("msvc.builder", {anonymous = true})
-        else
-            local _, toolname = target:tool("cxx")
-            raise("compiler(%s): does not support c++ module!", toolname)
-        end
-        support.memcache():set2("builder", cachekey, builder)
+function _get_headerunit_buildgroup_for(target)
+    return target:fullname() .. "/headerunit/build"
+end
+
+function _get_headerunit_buildfilejob_for(target, sourcefile)
+    return _get_headerunit_buildgroup_for(target) .. "/" .. sourcefile
+end
+
+function _get_buildfilejob_for(target, sourcefile, opt)
+    if opt and opt.headerunit then
+        return _get_headerunit_buildfilejob_for(target, sourcefile)
     end
-    return builder
+    return _get_module_buildfilejob_for(target, sourcefile, opt.type)
 end
 
-function mark_build(target, name)
-    support.memcache():set2("should_build_in_" .. target:fullname(), name, true)
+function _get_jobdeps(target, module, jobgraph, buildfilejob)
+
+    local memcache = support.memcache()
+    local jobdeps = {}
+    local type = support.has_two_phase_compilation_support(target) and "bmi" or "onephase"
+    for dep_name, dep in pairs(module.deps) do
+        if dep.headerunit then
+            dep_name = dep_name .. dep.key
+        end
+        local dep_module = mapper.get(target, dep_name)
+        local dep_sourcefile = dep_module.sourcefile
+        if dep.headerunit then
+            dep_sourcefile = dep_sourcefile .. dep_module.key
+        end
+    
+        local reused, from = support.is_reused(target, dep_sourcefile)
+        local dep_jobname
+        if dep_module.headerunit then
+            dep_jobname = _get_headerunit_buildfilejob_for(reused and from or target, dep_sourcefile)
+        else
+            dep_jobname = _get_module_buildfilejob_for(reused and from or target, dep_sourcefile, type)
+        end
+        -- if dep_jobname is available, order it now
+        if jobgraph:has(dep_jobname) then
+            jobdeps[buildfilejob] = jobdeps[buildfilejob] or {}
+            table.insert(jobdeps[buildfilejob], dep_jobname)
+        -- if dep_jobname is not currently available, save deps for later ordering
+        else
+            local dependent_jobs = memcache:get2("dependent_jobs", dep_jobname) or {}
+            table.insert(dependent_jobs, buildfilejob)
+            memcache:set2("dependent_jobs", dep_jobname, dependent_jobs)
+        end
+    end
+    return jobdeps
+end
+
+function _get_saved_jobdeps_for(buildfilejob)
+
+    local memcache = support.memcache()
+    local dependent_jobs = memcache:get2("dependent_jobs", buildfilejob)
+    local jobdeps = {}
+    for _, dependent_job in ipairs(dependent_jobs) do
+        jobdeps[dependent_job] = jobdeps[dependent_job] or {}
+        table.insert(jobdeps[dependent_job], buildfilejob)
+    end
+    return jobdeps
+end
+
+-- should we build this module or headerunit ?
+function should_build(target, module)
+
+    local memcache = support.memcache()
+    local _should_build = memcache:get2(target:fullname(), "should_build_" .. module.sourcefile)
+    if _should_build == nil then
+        local key = module.headerunit and module.sourcefile .. module.key or module.sourcefile
+        local reused, from = support.is_reused(target, key)
+        if reused then
+            local build = should_build(from, module)
+            memcache:set2(target:fullname(), "should_build_" .. module.sourcefile, build)
+            return build
+        end
+        local compinst = compiler.load("cxx", {target = target})
+        local compflags = compinst:compflags({sourcefile = module.sourcefile, target = target})
+
+        local dependfile = target:dependfile(module.bmifile or module.objectfile)
+        local dependinfo = {}
+        dependinfo.files = {module.sourcefile}
+        dependinfo.values = {compinst:program(), compflags}
+        local objectfile_exists = module.headerunit and true or os.isfile(module.objectfile)
+        dependinfo.lastmtime = os.isfile(module.bmifile or module.objectfile) and objectfile_exists and os.mtime(dependfile) or 0
+
+        local old_dependinfo = target:is_rebuilt() and {} or (depend.load(dependfile) or {})
+        old_dependinfo.files = {module.sourcefile}
+
+        -- force rebuild a module if any of its module dependency is rebuilt
+        for dep_name, dep_module in table.orderpairs(module.deps) do
+            local mapped_dep = mapper.get(target, dep_module.headerunit and dep_name .. dep_module.key or dep_name)
+
+            if should_build(target, mapped_dep) then
+                depend.save(dependinfo, dependfile)
+                memcache:set2(target:fullname(), "should_build_" .. module.sourcefile, true)
+                return true
+            end
+        end
+
+        -- need build this object?
+        local dryrun = option.get("dry-run")
+        if dryrun or depend.is_changed(old_dependinfo, dependinfo) then
+            depend.save(dependinfo, dependfile)
+            memcache:set2(target:fullname(), "should_build_" .. module.sourcefile, true)
+            return true
+        end
+        memcache:set2(target:fullname(), "should_build_" .. module.sourcefile, false)
+        return false
+    end
+    return _should_build
+end
+
+-- build modules for jobgraph
+-- only build bmis if two phase compilation is supported
+-- it not build also objectfiles
+function build_modules_for_jobgraph(target, jobgraph, built_modules)
+    
+    local builder = _builder(target)
+    local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
+    local jobdeps = {}
+    local buildfilejobs = {}
+    
+    -- if two phase supported only build interface and implementation named modules bmi
+    local _built_modules = {}
+    for _, sourcefile in ipairs(built_modules) do
+        local module = mapper.get(target, sourcefile)
+        if module.interface or module.implementation then
+            table.insert(_built_modules, sourcefile)
+        else
+            if not support.is_bmionly(target, sourcefile) then
+                local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, "objectfile")
+                table.join2(jobdeps, _get_jobdeps(target, module, jobgraph, buildfilejob))
+                table.insert(buildfilejobs, buildfilejob)
+                local objbuildfilejob = target:fullname() .. "/obj/" .. sourcefile
+                if jobgraph:has(objbuildfilejob) then
+                    jobdeps[objbuildfilejob] = {buildfilejob}
+                end
+            end
+        end
+    end
+
+    -- add module jobs
+    local type = has_two_phase_compilation_support and "bmi" or "onephase"
+    local buildgroup = _get_module_buildgroup_for(target, type)
+    jobgraph:group(buildgroup, function()
+        for _, sourcefile in ipairs(_built_modules) do
+            local module = mapper.get(target, sourcefile)
+            local bmionly = support.is_bmionly(target, module.sourcefile)
+            local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, type)
+            table.insert(buildfilejobs, buildfilejob)
+            jobgraph:add(buildfilejob, function(_, _, jobopt)
+                -- build bmi if named job
+                jobopt.bmi = module.interface or module.implementation
+                -- build objectfile here if two phase compilation is not supported
+                jobopt.objectfile = not has_two_phase_compilation_support and not bmionly
+                builder.make_module_job(target, module, jobopt)
+            end)
+            table.join2(jobdeps, _get_jobdeps(target, module, jobgraph, buildfilejob))
+
+            -- if two phase compilation supported set jobdeps for objectfile job
+            if has_two_phase_compilation_support and not bmionly then
+                local objbuildfilejob = _get_module_buildfilejob_for(target, sourcefile, "objectfile")
+                jobdeps[objbuildfilejob] = {buildfilejob}
+            end
+        end
+    end)
+
+    -- insert saved jobdeps
+    for _, buildfilejob in ipairs(buildfilejobs) do
+        table.join2(jobdeps, _get_saved_jobdeps_for(buildfilejob))
+    end
+
+    -- apply jobdeps
+    for jobname, deps in pairs(jobdeps) do
+        for _, depname in ipairs(deps) do
+            jobgraph:add_orders(depname, jobname)
+        end
+    end
+end
+
+-- build modules objectfiles for jobgraph if two phase compilation is supported
+function build_objectfiles_for_jobgraph(target, jobgraph, built_modules)
+
+    local builder = _builder(target)
+    local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
+    local buildgroup = _get_module_buildgroup_for(target, "objectfile")
+    local _built_modules = {}
+    if has_two_phase_compilation_support then
+        _built_modules = built_modules
+    else
+        for _, sourcefile in ipairs(built_modules) do
+            local module = mapper.get(target, sourcefile)
+            if not module.interface and not module.implementation then
+                table.insert(_built_modules, sourcefile)
+            end
+        end
+    end
+    jobgraph:group(buildgroup, function()
+        for _, sourcefile in ipairs(_built_modules) do
+            if not support.is_bmionly(target, sourcefile) then
+                local module = mapper.get(target, sourcefile)
+                local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, "objectfile")
+                jobgraph:add(buildfilejob, function(_, _, jobopt)
+                    jobopt.bmi = false
+                    jobopt.objectfile = true
+                    builder.make_module_job(target, module, jobopt)
+                end)
+            end
+        end
+    end)
 end
 
 -- build batchjobs for modules
@@ -261,218 +290,274 @@ function build_batchjobs_for_modules(modules, batchjobs, rootjob)
     return buildjobs(modules, batchjobs, rootjob)
 end
 
--- build modules for batchjobs
-function build_modules_for_batchjobs(target, batchjobs, sourcebatch, modules, opt)
-    opt.rootjob = batchjobs:group_leave() or opt.rootjob
-    batchjobs:group_enter(target:fullname() .. "/module/build_modules", {rootjob = opt.rootjob})
+-- build modules for batchjobs (deprecated)
+function build_modules_for_batchjobs(target, batchjobs, built_modules, opt)
 
-    -- add populate module job
-    local modulesjobs = {}
-    local populate_jobname = target:fullname() .. "/module/populate_module_map"
-    modulesjobs[populate_jobname] = {
-        name = populate_jobname,
-        job = batchjobs:newjob(populate_jobname, function(_, _)
-            _try_reuse_modules(target, modules)
-            _builder(target).populate_module_map(target, modules)
-        end)
-    }
+    opt.rootjob = batchjobs:group_leave() or opt.rootjob
+    batchjobs:group_enter(target:fullname() .. "/build_cxxmodules_bmi", {rootjob = opt.rootjob})
+    
+    local builder = _builder(target)
+    local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
+
+    -- if two phase supported only build interface and implementation named modules bmi
+    local _built_modules = {}
+    for _, sourcefile in ipairs(built_modules) do
+        local module = mapper.get(target, sourcefile)
+        if module.interface or module.implementation then
+            table.insert(_built_modules, sourcefile)
+        end
+    end
 
     -- add module jobs
-    _build_modules(target, sourcebatch, modules, table.join(opt, {
-        build_module = function(deps, module, name, objectfile, cppfile)
-            local job_name = target:fullname() .. "/module/" .. path.normalize(name or cppfile)
-            modulesjobs[job_name] = _builder(target).make_module_buildjobs(target, batchjobs, job_name, deps,
-                {module = module, objectfile = objectfile, cppfile = cppfile})
-        end
-    }))
+    local jobs
+    local type = has_two_phase_compilation_support and "bmi" or "onephase"
+    for _, sourcefile in ipairs(_built_modules) do
+        jobs = jobs or {}
+        local bmionly = support.is_bmionly(target, sourcefile)
+        local module = mapper.get(target, sourcefile)
 
-    -- build batchjobs for modules
-    build_batchjobs_for_modules(modulesjobs, batchjobs, opt.rootjob)
+        local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, type)
+        local deps = {}
+        for dep_name, dep in pairs(module.deps) do
+            if dep.headerunit then
+                dep_name = dep_name .. dep.key
+            end
+            local dep_module = mapper.get(target, dep_name)
+            local dep_sourcefile = dep_module.sourcefile
+            if dep.headerunit then
+                dep_sourcefile = dep_sourcefile .. dep_module.key
+            end
+    
+            local reused, from = support.is_reused(target, dep_sourcefile)
+            local dep_jobname
+            if dep_module.headerunit then
+                dep_jobname = _get_headerunit_buildfilejob_for(reused and from or target, dep_sourcefile)
+            else
+                dep_jobname = _get_module_buildfilejob_for(reused and from or target, dep_sourcefile, type)
+            end
+            table.insert(deps, dep_jobname)
+        end
+        jobs[buildfilejob] = {
+            name = buildfilejob,
+            deps = deps,
+            sourcefile = module.sourcefile,
+            job = batchjobs:newjob(buildfilejob, function(_, _, jobopt)
+                -- build bmi if named job
+                jobopt.bmi = module.interface or module.implementation
+                -- build objectfile here if two phase compilation is not supported
+                jobopt.objectfile = not has_two_phase_compilation_support and not bmionly
+                builder.make_module_job(target, module, jobopt)
+            end)}
+    end
+
+    return jobs
 end
 
--- build modules for jobgraph
-function build_modules_for_jobgraph(target, jobgraph, sourcebatch, modules, opt)
-    local jobdeps = {}
-    local jobsize = jobgraph:size()
-    local build_modules_group = target:fullname() .. "/module/build_modules"
-    jobgraph:group(build_modules_group, function ()
+-- build modules objectfiles for batchjobs if two phase compilation is supported (deprecated)
+function build_objectfiles_for_batchjobs(target, batchjobs, built_modules, opt)
 
-        -- add populate module job
-        local populate_jobname = target:fullname() .. "/module/populate_module_map"
-        jobgraph:add(populate_jobname, function(index, total, opt)
-            _try_reuse_modules(target, modules)
-            _builder(target).populate_module_map(target, modules)
-        end)
-
-        -- add module jobs
-        _build_modules(target, sourcebatch, modules, table.join(opt, {
-            build_module = function(deps, module, name, objectfile, cppfile)
-                local jobname = target:fullname() .. "/module/" .. path.normalize(name or cppfile)
-                _builder(target).make_module_jobgraph(target, jobgraph, {
-                    module = module, objectfile = objectfile, cppfile = cppfile
-                })
-                jobdeps[jobname] = table.join(populate_jobname, deps)
-            end})
-        )
-    end)
-    if jobgraph:size() > jobsize then
-        return build_modules_group, jobdeps
+    opt.rootjob = batchjobs:group_leave() or opt.rootjob
+    batchjobs:group_enter(target:fullname() .. "/build_cxxmodules_objectfiles", {rootjob = opt.rootjob})
+    local builder = _builder(target)
+    local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
+    local _built_modules = {}
+    if has_two_phase_compilation_support then
+        _built_modules = built_modules
+    else
+        for _, sourcefile in ipairs(built_modules) do
+            local module = mapper.get(target, sourcefile)
+            if not module.interface and not module.implementation then
+                table.insert(_built_modules, sourcefile)
+            end
+        end
     end
+    
+    local jobs
+    for _, sourcefile in ipairs(_built_modules) do
+        if not support.is_bmionly(target, sourcefile) then
+            jobs = jobs or {}
+            local module = mapper.get(target, sourcefile)
+            local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, "objectfile")
+            jobs[buildfilejob] = {
+                name = buildfilejob,
+                sourcefile = module.sourcefile,
+                job = batchjobs:newjob(buildfilejob, function(_, _, jobopt)
+                    jobopt.bmi = false
+                    jobopt.objectfile = true
+                    builder.make_module_job(target, module, jobopt)
+                end)}
+        end
+    end
+
+    return jobs
 end
 
 -- build modules for batchcmds
-function build_modules_for_batchcmds(target, batchcmds, sourcebatch, modules, opt)
-    local depmtime = 0
+function build_modules_for_batchcmds(target, batchcmds, built_modules, opt)
+
     opt.progress = opt.progress or 0
-
-    _try_reuse_modules(target, modules)
-    _builder(target).populate_module_map(target, modules)
-
+    local depmtime = 0
     -- build modules
-    _build_modules(target, sourcebatch, modules, table.join(opt, {
-        build_module = function(_, module, _, objectfile, cppfile)
-            depmtime = math.max(depmtime, _builder(target).make_module_buildcmds(target, batchcmds, {
-                module = module, cppfile = cppfile, objectfile = objectfile, progress = opt.progress}))
-        end
-    }))
+    local builder = _builder(target)
+    local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
 
+    local _built_modules = {}
+    for _, sourcefile in ipairs(built_modules) do
+        local module = mapper.get(target, sourcefile)
+        if module.interface or module.implementation then
+            table.insert(_built_modules, sourcefile)
+        end
+    end
+
+    for _, sourcefile in ipairs(_built_modules) do
+        local bmionly = support.is_bmionly(target, sourcefile)
+        local module = mapper.get(target, sourcefile)
+        local jobopt = {}
+        jobopt.bmi = module.interface or module.implementation
+        jobopt.objectfile = not has_two_phase_compilation_support and not bmionly
+        jobopt.progress = opt.progress
+        depmtime = math.max(depmtime, builder.make_module_buildcmds(target, batchcmds, module, jobopt))
+    end
     batchcmds:set_depmtime(depmtime)
 end
 
--- build headerunits for batchjobs
-function build_headerunits_for_batchjobs(target, batchjobs, sourcebatch, modules, opt)
+-- build modules objectfiles for batchcmds if two phase compilation is supported
+function build_objectfiles_for_batchcmds(target, batchcmds, built_modules, opt)
 
-    local user_headerunits, stl_headerunits = scanner.get_headerunits(target, sourcebatch, modules)
-    if not user_headerunits and not stl_headerunits then
-       return
+    opt.progress = opt.progress or 0
+    local depmtime = 0
+    local builder = _builder(target)
+    local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
+    local _built_modules = {}
+    if has_two_phase_compilation_support then
+        _built_modules = built_modules
+    else
+        for _, sourcefile in ipairs(built_modules) do
+            local module = mapper.get(target, sourcefile)
+            if not module.interface and not module.implementation then
+            table.insert(_built_modules, sourcefile)
+            end
+        end
     end
+
+    for _, sourcefile in ipairs(_built_modules) do
+        if not support.is_bmionly(target, sourcefile) then
+            local module = mapper.get(target, sourcefile)
+            local jobopt = {}
+            jobopt.bmi = false
+            jobopt.objectfile = true
+            jobopt.progress = opt.progress
+            depmtime = math.max(depmtime, builder.make_module_buildcmds(target, batchcmds, module, jobopt))
+        end
+    end
+    batchcmds:set_depmtime(depmtime)
+end
+
+-- build headerunits for jobgraph
+function build_headerunits_for_jobgraph(target, jobgraph, built_stlheaderunits, built_headerunits)
+
+    local builder = _builder(target)
+    function make_headerunit_job(headerfile, opt)
+        local reused, from = support.is_reused(target, headerfile)
+        local _target = reused and from or target
+        local headerunit = mapper.get(target, headerfile)
+        if not headerunit.alias then
+            local buildfilejob = _get_headerunit_buildfilejob_for(_target, headerunit.sourcefile .. headerunit.key)
+            if not jobgraph:has(buildfilejob) then
+                jobgraph:add(buildfilejob, function(_, _, jobopt)
+                    builder.make_headerunit_job(_target, headerunit, table.join(jobopt, opt))
+                end)
+            end
+        end
+    end
+
+    local headerunit_buildgroup = _get_headerunit_buildgroup_for(target)
+    if built_stlheaderunits then
+        -- build stl header units first as other headerunits may need them
+        jobgraph:group(headerunit_buildgroup, function()
+            for _, headerfile in ipairs(built_stlheaderunits) do
+                make_headerunit_job(headerfile, {stl_headerunit = true})
+            end
+        end)
+    end
+    
+    if built_headerunits then
+        jobgraph:group(headerunit_buildgroup, function()
+            for _, headerfile in ipairs(built_headerunits) do
+                make_headerunit_job(headerfile)
+            end
+        end)
+    end
+end
+
+-- build headerunits for batchjobs
+function build_headerunits_for_batchjobs(target, batchjobs, built_stlheaderunits, built_headerunits, opt)
 
     -- we need new group(headerunits)
     -- e.g. group(build_modules) -> group(headerunits)
     opt.rootjob = batchjobs:group_leave() or opt.rootjob
-    batchjobs:group_enter(target:fullname() .. "/module/build_headerunits", {rootjob = opt.rootjob})
-
-    local build_headerunits = function(headerunits)
-        local modulesjobs = {}
-        _build_headerunits(target, headerunits, table.join(opt, {
-            build_headerunit = function(headerunit, key, bmifile, outputdir, build)
-                local job_name = target:fullname() .. "/module/" .. path.normalize(key)
-                local job = _builder(target).make_headerunit_buildjobs(target, job_name, batchjobs, headerunit, bmifile, outputdir, table.join(opt, {build = build}))
-                if job then
-                  modulesjobs[job_name] = job
-                end
-            end
-        }))
-        build_batchjobs_for_modules(modulesjobs, batchjobs, opt.rootjob)
-    end
-
-    -- build stl header units first as other headerunits may need them
-    if stl_headerunits then
-        opt.stl_headerunit = true
-        build_headerunits(stl_headerunits)
-    end
-    if user_headerunits then
-        opt.stl_headerunit = false
-        build_headerunits(user_headerunits)
-    end
-end
-
--- build headerunits for jobgraph
-function build_headerunits_for_jobgraph(target, jobgraph, sourcebatch, modules, opt)
-    local user_headerunits, stl_headerunits = scanner.get_headerunits(target, sourcebatch, modules)
-    if not user_headerunits and not stl_headerunits then
-       return
-    end
-
-    -- we need new group(headerunits)
-    -- e.g. group(build_modules) -> group(headerunits)
-    local jobsize = jobgraph:size()
-    local build_headerunits_group = target:fullname() .. "/module/build_headerunits"
-    jobgraph:group(build_headerunits_group, function ()
-        local build_headerunits = function(headerunits)
-            local modulesjobs = {}
-            _build_headerunits(target, headerunits, table.join(opt, {
-                build_headerunit = function(headerunit, key, bmifile, outputdir, build)
-                    local job_name = target:fullname() .. "/module/" .. path.normalize(key)
-                    _builder(target).make_headerunit_jobgraph(target,
-                        job_name, jobgraph, headerunit, bmifile, outputdir, table.join(opt, {build = build}))
-                end
-            }))
+    batchjobs:group_enter(target:fullname() .. "/build_headerunits", {rootjob = opt.rootjob})
+    local builder = _builder(target)
+    local jobs = {}
+    function make_headerunit_job(headerfile, opt)
+        local reused, from = support.is_reused(target, headerfile)
+        local _target = reused and from or target
+        local headerunit = mapper.get(target, headerfile)
+        if not headerunit.alias then
+            local buildfilejob = _get_headerunit_buildfilejob_for(_target, headerunit.sourcefile .. headerunit.key)
+            jobs[buildfilejob] = {
+                name = buildfilejob,
+                sourcefile = headerunit.sourcefile,
+                job = batchjobs:newjob(buildfilejob, function(_, _, jobopt)
+                    builder.make_headerunit_job(_target, headerunit, table.join(jobopt, opt))
+                end)}
         end
+    end
 
+    if built_stlheaderunits then
         -- build stl header units first as other headerunits may need them
-        if stl_headerunits then
-            opt.stl_headerunit = true
-            build_headerunits(stl_headerunits)
+        for _, headerfile in ipairs(built_stlheaderunits) do
+            make_headerunit_job(headerfile, {stl_headerunit = true})
         end
-        if user_headerunits then
-            opt.stl_headerunit = false
-            build_headerunits(user_headerunits)
-        end
-    end)
-    if jobgraph:size() > jobsize then
-        return build_headerunits_group
     end
+    
+    if built_headerunits then
+        for _, headerfile in ipairs(built_headerunits) do
+            make_headerunit_job(headerfile)
+        end
+    end
+    return jobs
 end
 
 -- build headerunits for batchcmds
-function build_headerunits_for_batchcmds(target, batchcmds, sourcebatch, modules, opt)
-    local user_headerunits, stl_headerunits = scanner.get_headerunits(target, sourcebatch, modules)
-    if not user_headerunits and not stl_headerunits then
-       return
-    end
+function build_headerunits_for_batchcmds(target, batchcmds, built_stlheaderunits, built_headerunits, opt)
 
-    local build_headerunits = function(headerunits)
-        local depmtime = 0
-        _build_headerunits(target, headerunits, table.join(opt, {
-            build_headerunit = function(headerunit, _, bmifile, outputdir, build)
-                depmtime = math.max(depmtime, _builder(target).make_headerunit_buildcmds(target, batchcmds, headerunit, bmifile, outputdir, table.join({build = build}, opt)))
-            end
-        }))
-        batchcmds:set_depmtime(depmtime)
+    local builder = _builder(target)
+    function make_headerunit_buildcmds(headerfile, jobopt)
+        local reused, from = support.is_reused(target, headerfile)
+        local _target = reused and from or target
+        local headerunit = mapper.get(target, headerfile)
+        if not headerunit.alias then
+            builder.make_headerunit_buildcmds(_target, batchcmds, headerunit, table.join(opt, jobopt))
+        end
     end
 
     -- build stl header units first as other headerunits may need them
-    if stl_headerunits then
-        opt.stl_headerunit = true
-        build_headerunits(stl_headerunits)
+    -- opt.stl_headerunit = true
+    for _, headerfile in ipairs(built_stlheaderunits) do
+        make_headerunit_buildcmds(headerfile, {stl_headerunit = true})
     end
-    if user_headerunits then
-        opt.stl_headerunit = false
-        build_headerunits(user_headerunits)
-    end
-end
-
--- build modules and headerunits, and we need to build headerunits first
-function build_modules_and_headerunits(target, jobgraph, sourcebatch, modules, opt)
-    if jobgraph.add_orders then
-        local build_modules_group, jobdeps = build_modules_for_jobgraph(target, jobgraph, sourcebatch, modules, opt)
-        local build_headerunits_group = build_headerunits_for_jobgraph(target, jobgraph, sourcebatch, modules, opt)
-        if build_modules_group then
-            for jobname, deps in pairs(jobdeps) do
-                for _, depname in ipairs(deps) do
-                    jobgraph:add_orders(depname, jobname)
-                end
-            end
-            if build_headerunits_group then
-                jobgraph:add_orders(build_headerunits_group, build_modules_group)
-            end
-        end
-    elseif jobgraph.runcmds then
-        build_headerunits_for_batchcmds(target, jobgraph, sourcebatch, modules, opt)
-        build_modules_for_batchcmds(target, jobgraph, sourcebatch, modules, opt)
-    elseif jobgraph.newjob then -- deprecated
-        build_modules_for_batchjobs(target, jobgraph, sourcebatch, modules, opt)
-        build_headerunits_for_batchjobs(target, jobgraph, sourcebatch, modules, opt)
+    -- opt.stl_headerunit = false
+    for _, headerfile in ipairs(built_headerunits) do
+        make_headerunit_buildcmds(headerfile)
     end
 end
 
--- generate metadata
 function generate_metadata(target, modules)
+
     local public_modules
-    for _, module in table.orderpairs(modules) do
-        local _, _, cppfile = support.get_provided_module(module)
-        local fileconfig = target:fileconfig(cppfile)
+    for sourcefile, module in table.orderpairs(modules) do
+        local fileconfig = target:fileconfig(sourcefile)
         local public = fileconfig and fileconfig.public
         if public then
             public_modules = public_modules or {}
@@ -485,80 +570,20 @@ function generate_metadata(target, modules)
     end
 
     local jobs = option.get("jobs") or os.default_njob()
-    runjobs(target:fullname() .. "/module/install_modules", function(index, total, jobopt)
+    runjobs(target:fullname() .. "_install_modules", function(index, _, jobopt)
         local module = public_modules[index]
-        local name, _, cppfile = support.get_provided_module(module)
-        local metafilepath = support.get_metafile(target, cppfile)
-        progress.show(jobopt.progress, "${color.build.target}<%s> generating.module.metadata %s", target:fullname(), name)
-        local metadata = _generate_meta_module_info(target, name, cppfile, module.requires)
+        local metafilepath = support.get_metafile(target, module)
+        progress.show(jobopt.progress, "${color.build.target}<%s> generating.module.metadata %s", target:fullname(), module.name)
+        local metadata = _generate_meta_module_info(target, module)
         json.savefile(metafilepath, metadata)
     end, {comax = jobs, total = #public_modules})
 end
 
--- flush target module mapper keys
-function flush_target_module_mapper_keys(target)
-    local memcache = support.memcache()
-    memcache:set2(target:fullname(), "module_mapper_keys", nil)
-end
-
--- get or create a target module mapper
-function get_target_module_mapper(target)
-    local memcache = support.memcache()
-    local mapper = memcache:get2(target:fullname(), "module_mapper")
-    if not mapper then
-        mapper = {}
-        memcache:set2(target:fullname(), "module_mapper", mapper)
-    end
-
-    -- we generate the keys map to optimise the efficiency of _is_duplicated_headerunit
-    local mapper_keys = memcache:get2(target:fullname(), "module_mapper_keys")
-    if not mapper_keys then
-        mapper_keys = {}
-        for _, item in pairs(mapper) do
-            if item.key then
-                mapper_keys[item.key] = item
-            end
-        end
-        memcache:set2(target:fullname(), "module_mapper_keys", mapper_keys)
-    end
-    return mapper, mapper_keys
-end
-
--- get a module or headerunit from target mapper
-function get_from_target_mapper(target, name)
-    local mapper = get_target_module_mapper(target)
-    if mapper[name] then
-        return mapper[name]
-    end
-end
-
--- add a module to target mapper
-function add_module_to_target_mapper(target, name, sourcefile, bmifile, opt)
-    local mapper = get_target_module_mapper(target)
-    if not mapper[name] then
-        mapper[name] = {name = name, key = name, bmi = bmifile, sourcefile = sourcefile, opt = opt}
-    end
-    flush_target_module_mapper_keys(target)
-end
-
--- add a headerunit to target mapper
-function add_headerunit_to_target_mapper(target, headerunit, bmifile)
-    local mapper = get_target_module_mapper(target)
-    local key = hash.uuid(path.normalize(headerunit.path))
-    local deduplicated = _is_duplicated_headerunit(target, key)
-    if deduplicated then
-        mapper[headerunit.name] = {name = headerunit.name, key = key, aliasof = deduplicated.name, headerunit = headerunit}
-    else
-        mapper[headerunit.name] = {name = headerunit.name, key = key, headerunit = headerunit, bmi = bmifile}
-    end
-    flush_target_module_mapper_keys(target)
-    return deduplicated and true or false
-end
-
 -- check if dependencies changed
 function is_dependencies_changed(target, module)
-    local cachekey = target:fullname() .. module.name
-    local requires = hashset.from(table.keys(module.requires or {}))
+
+    local cachekey = target:fullname() .. (module.name or module.sourcefile)
+    local requires = hashset.from(table.keys(module.deps or {}))
     local oldrequires = support.memcache():get2(cachekey, "oldrequires")
     local changed = false
     if oldrequires then
@@ -576,43 +601,96 @@ function is_dependencies_changed(target, module)
     return requires, changed
 end
 
--- patch sourcebatch
-function patch_sourcebatch(target, sourcebatch, opt)
+function clean(target)
 
-    -- add target deps modules
-    if target:orderdeps() then
-        local deps_sourcefiles = scanner.get_targetdeps_modules(target)
-        if deps_sourcefiles then
-            table.join2(sourcebatch.sourcefiles, deps_sourcefiles)
+    -- we cannot use target:data("cxx.has_modules"),
+    -- because on_config will be not called when cleaning targets
+    if support.contains_modules(target) then
+        remove_files(support.modules_cachedir(target, {interface = true}))
+        remove_files(support.modules_cachedir(target, {interface = false}))
+        remove_files(support.modules_cachedir(target, {headerunit = true}))
+        if option.get("all") then
+            support.localcache():clear()
+            support.localcache():save()
         end
     end
+end
 
-    -- append std module
-    local std_modules = support.get_stdmodules(target)
-    if std_modules then
-        table.join2(sourcebatch.sourcefiles, std_modules)
-    end
+function build_bmis(target, jobgraph, _, opt)
+    opt = opt or {}
+    if target:data("cxx.has_modules") then
+        if target:is_moduleonly() and not target:data("cxx.modules.reused") then
+            return
+        end
+        local modules = scanner.get_modules(target)
+        -- avoid building non referenced modules
+        local built_modules, built_headerunits, _ = scanner.sort_modules_by_dependencies(target, modules, {jobgraph = target:policy("build.jobgraph")})
+        local headerunits, stlheaderunits = scanner.sort_headerunits(target, built_headerunits)
 
-    -- extract packages modules dependencies
-    local package_modules_data = scanner.get_all_packages_modules(target, opt)
-    if package_modules_data then
-        -- append to sourcebatch
-        for _, package_module_data in table.orderpairs(package_modules_data) do
-            table.insert(sourcebatch.sourcefiles, package_module_data.file)
-            target:fileconfig_set(package_module_data.file, {external = package_module_data.external, defines = package_module_data.metadata.defines})
+        if jobgraph.add_orders then -- jobgraph
+            -- build headerunits
+            if stlheaderunits or headerunits then
+                build_headerunits_for_jobgraph(target, jobgraph, stlheaderunits, headerunits)
+            end
+
+            -- build modules
+            build_modules_for_jobgraph(target, jobgraph, built_modules)
+        elseif jobgraph.newjob then -- batchjobs (deprecated)
+            opt.batchjobs = true
+            -- build headerunits
+            local jobs = build_headerunits_for_batchjobs(target, jobgraph, stlheaderunits, headerunits, opt)
+
+            -- build modules
+            jobs = table.join(build_modules_for_batchjobs(target, jobgraph, built_modules, opt) or {}, jobs or {})
+
+            build_batchjobs_for_modules(jobs, jobgraph, opt.rootjob)
+        elseif jobgraph.runcmds then -- batchcmds
+            opt.progress = opt.progress or 0
+            -- build headerunits
+            build_headerunits_for_batchcmds(target, jobgraph, stlheaderunits, headerunits, opt)
+
+            local append_requires_flags = _builder(target).append_requires_flags
+            if append_requires_flags then
+                append_requires_flags(target, built_modules)
+            end
+
+            -- build modules
+            build_modules_for_batchcmds(target, jobgraph, built_modules, opt)
+        else
+            assert(false, "shouldn't be here :D")
         end
     end
+end
 
-    -- patch objectfiles and dependencies
-    sourcebatch.sourcekind = "cxx"
-    sourcebatch.objectfiles = {}
-    sourcebatch.dependfiles = {}
-    for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
-        local objectfile = target:objectfile(sourcefile)
-        table.insert(sourcebatch.objectfiles, objectfile)
+function build_objectfiles(target, jobgraph, _, opt)
+    
+    if target:data("cxx.has_modules") then
+        if target:is_moduleonly() and not target:data("cxx.modules.reused") then
+            return
+        end
+        local modules = scanner.get_modules(target)
+        -- avoid building non referenced modules
+        local built_modules, _, _ = scanner.sort_modules_by_dependencies(target, modules, {jobgraph = target:policy("build.jobgraph")})
+        local append_requires_flags = _builder(target).append_requires_flags
+        if append_requires_flags then
+            append_requires_flags(target, built_modules)
+        end
 
-        local dependfile = target:dependfile(sourcefile or objectfile)
-        table.insert(sourcebatch.dependfiles, dependfile)
+        if jobgraph.add_orders then -- jobgraph
+            -- build modules objectfiles
+            build_objectfiles_for_jobgraph(target, jobgraph, built_modules)
+        elseif jobgraph.newjob then -- batchjobs (deprecated)
+            opt.batchjobs = true
+            -- build modules objectfiles
+            local jobs = table.join(build_objectfiles_for_batchjobs(target, jobgraph, built_modules, opt) or {}, jobs or {})
+
+            build_batchjobs_for_modules(jobs, jobgraph, opt.rootjob)
+        elseif jobgraph.runcmds then -- batchcmds
+            -- build modules objectfiles
+            build_objectfiles_for_batchcmds(target, jobgraph, built_modules, opt)
+        else
+            assert(false, "shouldn't be here :D")
+        end
     end
 end
 

--- a/xmake/rules/c++/modules/clang/builder.lua
+++ b/xmake/rules/c++/modules/clang/builder.lua
@@ -28,64 +28,72 @@ import("core.tool.compiler")
 import("core.project.config")
 import("core.project.depend")
 import("support")
+import(".mapper")
 import(".builder", {inherit = true})
 
-function _compile_one_step(target, bmifile, sourcefile, objectfile, opt)
-    local module_outputflag = support.get_moduleoutputflag(target)
-    if opt.is_mapped_bmi then
-        -- get flags
-        if module_outputflag then
-            local flags = table.join(opt.std and {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier"} or {})
-            if opt and opt.batchcmds then
-                _batchcmds_compile(opt.batchcmds, target, flags, bmifile, objectfile)
-            else
-                _compile(target, flags, bmifile, objectfile)
-            end
+function _make_modulebuildflags(target, module, opt)
+
+    local flags = {}
+    if opt and opt.bmi then
+        local module_outputflag = support.get_moduleoutputflag(target)
+
+        flags = {"-x", "c++-module"}
+        if not opt.objectfile then
+            table.insert(flags, "--precompile")
+        end
+        local std = (module.name == "std" or module.name == "std.compat")
+        if std then
+            table.join2(flags, {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier", "-Wno-deprecated-declarations"})
+        end
+        table.insert(flags, module_outputflag .. module.bmifile)
+    end
+
+    return flags
+end
+
+function _compile_one_step(target, module, opt)
+
+    -- get flags
+    if module_outputflag then
+        local flags = _make_modulebuildflags(target, module, {bmi = true, objectfile = true})
+        if opt and opt.batchcmds then
+            _batchcmds_compile(opt.batchcmds, target, flags, module.sourcefile, module.objectfile)
         else
-            _compile_objectfile_step(target, bmifile, sourcefile, objectfile, opt)
+            _compile(target, flags, module.sourcefile, module.objectfile)
         end
     else
-        -- get flags
-        if module_outputflag then
-            local flags = table.join({"-x", "c++-module", module_outputflag .. bmifile}, opt.std and {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier"} or {})
-            if opt and opt.batchcmds then
-                _batchcmds_compile(opt.batchcmds, target, flags, sourcefile, objectfile)
-            else
-                _compile(target, flags, sourcefile, objectfile)
-            end
-        else
-            _compile_bmi_step(target, bmifile, sourcefile, opt)
-            _compile_objectfile_step(target, bmifile, sourcefile, objectfile, opt)
-        end
+        _compile_bmi_step(target, module, opt)
+        _compile_objectfile_step(target, module, opt)
     end
 end
 
-function _compile_bmi_step(target, bmifile, sourcefile, opt)
-    local flags = table.join({"-x", "c++-module", "--precompile"}, opt.std and {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier"} or {})
+function _compile_bmi_step(target, module, opt)
+
+    local flags = _make_modulebuildflags(target, module, {bmi = true, objectfile = false})
     if opt and opt.batchcmds then
-        _batchcmds_compile(opt.batchcmds, target, flags, sourcefile, bmifile)
+        _batchcmds_compile(opt.batchcmds, target, flags, module.sourcefile, module.bmifile, opt)
     else
-        _compile(target, flags, sourcefile, bmifile)
+        _compile(target, flags, module.sourcefile, module.bmifile)
     end
 end
 
-function _compile_objectfile_step(target, bmifile, sourcefile, objectfile, opt)
-    _compile(target, {}, sourcefile, objectfile, {bmifile = bmifile})
+function _compile_objectfile_step(target, module, opt)
+    local flags = _make_modulebuildflags(target, module, {bmi = false, objectfile = false})
     if opt and opt.batchcmds then
-        _batchcmds_compile(opt.batchcmds, target, {}, sourcefile, objectfile, {bmifile = bmifile})
+        _batchcmds_compile(opt.batchcmds, target, flags, module.sourcefile, module.objectfile, {bmifile = module.bmifile})
     else
-        _compile(target, {}, sourcefile, objectfile, {bmifile = bmifile})
+        _compile(target, flags, module.sourcefile, module.objectfile, {bmifile = module.bmifile})
     end
 end
 
 -- get flags for building a headerunit
-function _make_headerunitflags(target, headerunit, bmifile)
+function _make_headerunitflags(target, headerunit)
 
     local module_headerflag = support.get_moduleheaderflag(target)
     assert(module_headerflag, "compiler(clang): does not support c++ header units!")
 
     local local_directory = (headerunit.type == ":quote") and {"-I" .. path.directory(headerunit.path)} or {}
-    local headertype = (headerunit.type == ":angle") and "system" or "user"
+    local headertype = (headerunit.method == "include-quote") and "system" or "user"
     local flags = table.join(local_directory, {"-xc++-header", "-Wno-everything", module_headerflag .. headertype})
     return flags
 end
@@ -96,17 +104,19 @@ function _compile(target, flags, sourcefile, outputfile, opt)
     opt = opt or {}
     local dryrun = option.get("dry-run")
     local compinst = target:compiler("cxx")
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local flags = table.join(compflags or {}, flags)
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
+    flags = table.join(flags or {}, compflags or {})
+
+    local bmifile = opt and opt.bmifile
 
     -- trace
     if option.get("verbose") then
-        print(compinst:compcmd(opt.bmifile or sourcefile, outputfile, {target = target, compflags = flags, rawargs = true}))
+        print(compinst:compcmd(bmifile or sourcefile, outputfile, {target = target, compflags = flags, sourcekind = "cxx", rawargs = true}))
     end
 
     -- do compile
     if not dryrun then
-        assert(compinst:compile(opt.bmifile or sourcefile, outputfile, {target = target, compflags = flags}))
+        assert(compinst:compile(bmifile or sourcefile, outputfile, {target = target, compflags = flags}))
     end
 end
 
@@ -115,7 +125,7 @@ end
 function _batchcmds_compile(batchcmds, target, flags, sourcefile, outputfile, opt)
     opt = opt or {}
     local compinst = target:compiler("cxx")
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
     flags = table.join("-c", compflags or {}, flags, {"-o", outputfile, opt.bmifile or sourcefile})
     batchcmds:compilev(flags, {compiler = compinst, sourcekind = "cxx"})
 end
@@ -130,45 +140,44 @@ end
 -- -fmodule-file=build/.gens/Foo/rules/modules/cache/iostream.pcm
 -- -fmodule-file=build/.gens/Foo/rules/modules/cache/bar.hpp.pcm
 --
-function _get_requiresflags(target, module, opt)
+function _get_requiresflags(target, module)
 
     local modulefileflag = support.get_modulefileflag(target)
-    local name = module.name
+    local name = module.name or module.sourcefile
     local cachekey = target:fullname() .. name
 
     local requires, requires_changed = is_dependencies_changed(target, module)
     local requiresflags = support.memcache():get2(cachekey, "requiresflags")
     if not requiresflags or requires_changed then
         requiresflags = {}
-        for required in requires:orderitems() do
-            local dep_module = get_from_target_mapper(target, required)
+        for required, dep in pairs(module.deps) do
+            if dep.headerunit then
+                required = required .. dep.key
+            end
+            local dep_module = mapper.get(target, required)
             assert(dep_module, "module dependency %s required for %s not found", required, name)
 
-            -- aliased headerunit
-            local bmifile = dep_module.bmi
-            if dep_module.aliasof then
-                local aliased = get_from_target_mapper(target, dep_module.aliasof)
-                bmifile = aliased.bmi
-            end
-            local mapflag = (dep_module.opt and dep_module.opt.namedmodule) and format("%s%s=%s", modulefileflag, required, bmifile) or modulefileflag .. bmifile
+            local mapflag = dep_module.headerunit and modulefileflag .. dep_module.bmifile or format("%s%s=%s", modulefileflag, required, dep_module.bmifile)
             table.insert(requiresflags, mapflag)
 
             -- append deps
-            if dep_module.opt and dep_module.opt.deps then
-                local deps = _get_requiresflags(target, {name = dep_module.name or dep_module.sourcefile, bmi = bmifile, requires = dep_module.opt.deps})
+            if dep_module.deps then
+                local deps = _get_requiresflags(target, dep_module)
                 table.join2(requiresflags, deps)
             end
         end
         requiresflags = table.unique(requiresflags)
+        table.sort(requiresflags)
         support.memcache():set2(cachekey, "requiresflags", requiresflags)
         support.memcache():set2(cachekey, "oldrequires", requires)
     end
     return requiresflags
 end
 
-function _append_requires_flags(target, module, name, cppfile, bmifile, opt)
+function _append_requires_flags(target, module)
+
     local cxxflags = {}
-    local requiresflags = _get_requiresflags(target, {name = (name or cppfile), bmi = bmifile, requires = module.requires})
+    local requiresflags = _get_requiresflags(target, module)
     for _, flag in ipairs(requiresflags) do
         -- we need to wrap flag to support flag with space
         if type(flag) == "string" and flag:find(" ", 1, true) then
@@ -177,297 +186,131 @@ function _append_requires_flags(target, module, name, cppfile, bmifile, opt)
             table.insert(cxxflags, flag)
         end
     end
-    target:fileconfig_add(cppfile, {force = {cxxflags = cxxflags}})
+    target:fileconfig_add(module.sourcefile, {force = {cxxflags = cxxflags}})
 end
 
--- populate module map
-function populate_module_map(target, modules)
-    local clang_version = support.get_clang_version(target)
-    local support_namedmodule = semver.compare(clang_version, "16.0") >= 0
-    for _, module in pairs(modules) do
-        local name, provide, cppfile = support.get_provided_module(module)
-        if provide then
-            local bmifile = support.get_bmi_path(provide.bmi)
-            add_module_to_target_mapper(target, name, cppfile, bmifile, {deps = module.requires, namedmodule = support_namedmodule})
-        end
-    end
-end
-
--- get defines for a module
-function get_module_required_defines(target, sourcefile)
-    local compinst = compiler.load("cxx", {target = target})
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local defines
-    for _, flag in ipairs(compflags) do
-        if flag:startswith("-D") then
-            defines = defines or {}
-            table.insert(defines, flag:sub(3))
-        end
-    end
-    return defines
-end
-
--- build module file for batchjobs
-function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
-
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-    local dryrun = option.get("dry-run")
-
-    return {
-        name = job_name,
-        deps = table.join(target:fullname() .. "/module/populate_module_map", deps),
-        sourcefile = opt.cppfile,
-        job = batchjobs:newjob(target:fullname() .. "/module/" .. (name or opt.cppfile), function(index, total, jobopt)
-            local mapped_bmi
-            if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-                mapped_bmi = get_from_target_mapper(target, name).bmi
-            end
-
-            local build, dependinfo
-            local dependfile = target:dependfile(bmifile or opt.objectfile)
-            if provide or support.has_module_extension(opt.cppfile) then
-                build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-
-                -- needed to detect rebuild of dependencies
-                if provide and build then
-                    mark_build(target, name)
-                end
-            end
-
-            -- append requires flags
-            if opt.module.requires then
-                _append_requires_flags(target, opt.module, name, opt.cppfile, bmifile, opt)
-            end
-
-            -- for cpp file we need to check after appendings the flags
-            if build == nil then
-                build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-            end
-
-            if build then
-                -- compile if it's a named module
-                if provide or support.has_module_extension(opt.cppfile) then
-                    if not dryrun then
-                        local objectdir = path.directory(opt.objectfile)
-                        if not os.isdir(objectdir) then
-                            os.mkdir(objectdir)
-                        end
-                    end
-
-                    local fileconfig = target:fileconfig(opt.cppfile)
-                    local public = fileconfig and fileconfig.public
-                    local external = fileconfig and fileconfig.external
-                    local from_moduleonly = external and external.moduleonly
-                    local bmifile = mapped_bmi or bmifile
-                    local is_mapped_bmi = mapped_bmi ~= nil
-                    if external and not from_moduleonly then
-                        if not mapped_bmi then
-                            progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                            _compile_bmi_step(target, bmifile, opt.cppfile, {std = (name == "std" or name == "std.compat")})
-                        end
-                    else
-                        progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-                        _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {std = (name == "std" or name == "std.compat"), is_mapped_bmi = is_mapped_bmi})
-                    end
-                else
-                    os.tryrm(opt.objectfile) -- force rebuild for .cpp files
-                end
-                depend.save(dependinfo, dependfile)
-            end
-        end)}
-end
-
--- build module file for jobgraph
-function make_module_jobgraph(target, jobgraph, opt)
-
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-    local dryrun = option.get("dry-run")
-
-    local jobname = target:fullname() .. "/module/" .. (name or opt.cppfile)
-    jobgraph:add(jobname, function(index, total, jobopt)
-        local mapped_bmi
-        if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-            mapped_bmi = get_from_target_mapper(target, name).bmi
-        end
-
-        local build, dependinfo
-        local dependfile = target:dependfile(bmifile or opt.objectfile)
-        if provide or support.has_module_extension(opt.cppfile) then
-            build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-
-            -- needed to detect rebuild of dependencies
-            if provide and build then
-                mark_build(target, name)
-            end
-        end
-
-        -- append requires flags
-        if opt.module.requires then
-            _append_requires_flags(target, opt.module, name, opt.cppfile, bmifile, opt)
-        end
-
-        -- for cpp file we need to check after appendings the flags
-        if build == nil then
-            build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-        end
-
-        if build then
-            -- compile if it's a named module
-            if provide or support.has_module_extension(opt.cppfile) then
-                if not dryrun then
-                    local objectdir = path.directory(opt.objectfile)
-                    if not os.isdir(objectdir) then
-                        os.mkdir(objectdir)
-                    end
-                end
-
-                local fileconfig = target:fileconfig(opt.cppfile)
-                local public = fileconfig and fileconfig.public
-                local external = fileconfig and fileconfig.external
-                local from_moduleonly = external and external.moduleonly
-                local bmifile = mapped_bmi or bmifile
-                local is_mapped_bmi = mapped_bmi ~= nil
-                if external and not from_moduleonly then
-                    if not mapped_bmi then
-                        progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                        _compile_bmi_step(target, bmifile, opt.cppfile, {std = (name == "std" or name == "std.compat")})
-                    end
-                else
-                    progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-                    _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {std = (name == "std" or name == "std.compat"), is_mapped_bmi = is_mapped_bmi})
-                end
-            else
-                os.tryrm(opt.objectfile) -- force rebuild for .cpp files
-            end
-            depend.save(dependinfo, dependfile)
-        end
-    end)
-end
-
-
--- build module file for batchcmds
-function make_module_buildcmds(target, batchcmds, opt)
-
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-
-    local mapped_bmi
-    if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-        mapped_bmi = get_from_target_mapper(target, name).bmi
-    end
+function append_requires_flags(target, built_modules)
 
     -- append requires flags
-    if opt.module.requires then
-        _append_requires_flags(target, opt.module, name, opt.cppfile, bmifile, opt)
-    end
-
-    -- compile if it's a named module
-    if provide or support.has_module_extension(opt.cppfile) then
-        batchcmds:mkdir(path.directory(opt.objectfile))
-
-        local fileconfig = target:fileconfig(opt.cppfile)
-        local public = fileconfig and fileconfig.public
-        local external = fileconfig and fileconfig.external
-        local bmifile = mapped_bmi or bmifile
-        local is_mapped_bmi = mapped_bmi ~= nil
-        if external and not from_moduleonly then
-            if not mapped_bmi then
-                batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                _compile_bmi_step(target, bmifile, opt.cppfile, {std = (name == "std" or name == "std.compat"), batchcmds = batchcmds})
-            end
-        else
-            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-            _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {std = (name == "std" or name == "std.compat"), batchcmds = batchcmds, is_mapped_bmi = is_mapped_bmi})
+    for _, sourcefile in ipairs(built_modules) do
+        local module = mapper.get(target, sourcefile)
+        if module.deps then
+            _append_requires_flags(target, module)
         end
-    else
-        batchcmds:rm(opt.objectfile) -- force rebuild for .cpp files
-    end
-    batchcmds:add_depfiles(opt.cppfile)
-    return os.mtime(opt.objectfile)
-end
-
--- build headerunit file for batchjobs
-function make_headerunit_buildjobs(target, job_name, batchjobs, headerunit, bmifile, outputdir, opt)
-    local already_exists = add_headerunit_to_target_mapper(target, headerunit, bmifile)
-    if not already_exists then
-        return {
-            name = job_name,
-            sourcefile = headerunit.path,
-            job = batchjobs:newjob(job_name, function(index, total, jobopt)
-                if not os.isdir(outputdir) then
-                    os.mkdir(outputdir)
-                end
-
-                local compinst = compiler.load("cxx", {target = target})
-                local compflags = compinst:compflags({sourcefile = headerunit.path, target = target})
-
-                local dependfile = target:dependfile(bmifile)
-                local dependinfo = depend.load(dependfile) or {}
-                dependinfo.files = {}
-                local depvalues = {compinst:program(), compflags}
-
-                if opt.build then
-                    progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s",
-                        target:fullname(), headerunit.name)
-                    _compile(target, _make_headerunitflags(target, headerunit, bmifile), headerunit.path, bmifile)
-                end
-
-                table.insert(dependinfo.files, headerunit.path)
-                dependinfo.values = depvalues
-                depend.save(dependinfo, dependfile)
-            end)}
     end
 end
 
--- build headerunit file for jobgraph
-function make_headerunit_jobgraph(target, job_name, jobgraph, headerunit, bmifile, outputdir, opt)
-    local already_exists = add_headerunit_to_target_mapper(target, headerunit, bmifile)
-    if not already_exists then
-        jobgraph:add(job_name, function(index, total, jobopt)
-            if not os.isdir(outputdir) then
-                os.mkdir(outputdir)
+-- build module file for batchjobs / jobgraph
+function make_module_job(target, module, opt)
+
+    local dryrun = option.get("dry-run")
+
+    -- append requires flags
+    -- if module.deps then
+    --     _append_requires_flags(target, module)
+    -- end
+
+    local build = should_build(target, module)
+    local bmi = opt and opt.bmi
+    local objectfile = opt and opt.objectfile
+
+    if build then
+        if not dryrun then
+            local objectdir = path.directory(module.objectfile)
+            if not os.isdir(objectdir) then
+                os.mkdir(objectdir)
             end
-
-            local compinst = compiler.load("cxx", {target = target})
-            local compflags = compinst:compflags({sourcefile = headerunit.path, target = target})
-
-            local dependfile = target:dependfile(bmifile)
-            local dependinfo = depend.load(dependfile) or {}
-            dependinfo.files = {}
-            local depvalues = {compinst:program(), compflags}
-
-            if opt.build then
-                progress.show(jobopt.progress,
-                    "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s",
-                    target:fullname(), headerunit.name)
-                _compile(target, _make_headerunitflags(target, headerunit, bmifile), headerunit.path, bmifile)
+            if module.bmifile then
+                local bmidir = path.directory(module.bmifile)
+                if not os.isdir(bmidir) then
+                    os.mkdir(bmidir)
+                end
             end
+        end
 
-            table.insert(dependinfo.files, headerunit.path)
-            dependinfo.values = depvalues
-            depend.save(dependinfo, dependfile)
-        end)
+        if bmi and objectfile then
+            progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), module.name)
+            _compile_one_step(target, module)
+        elseif bmi then
+            progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.bmi.$(mode) %s", target:fullname(), module.name)
+            _compile_bmi_step(target, module)
+        else
+            if module.interface or module.implementation then
+                progress.show(opt.progress, "compiling.$(mode) %s", module.sourcefile)
+                _compile_objectfile_step(target, module)
+            else
+                os.tryrm(module.objectfile) -- force rebuild for .cpp files
+            end
+        end
+    end
+end
+
+-- build module file for batchcmds
+function make_module_buildcmds(target, batchcmds, module, opt)
+
+    local build = should_build(target, module)
+    local bmi = opt and opt.bmi
+    local objectfile = opt and opt.objectfile
+
+    if build then
+        if not dryrun then
+            local objectdir = path.directory(module.objectfile)
+            batchcmds:mkdir(objectdir)
+            if module.bmifile then
+                local bmidir = path.directory(module.bmifile)
+                batchcmds:mkdir(bmidir)
+            end
+        end
+
+        if bmi and objectfile then
+            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), module.name)
+            _compile_one_step(target, module, {batchcmds = batchcmds})
+        elseif bmi then
+            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.bmi.$(mode) %s", target:fullname(), module.name)
+            _compile_bmi_step(target, module, {batchcmds = batchcmds})
+        else
+            if module.interface or module.implementation then
+                batchcmds:show_progress(opt.progress, "compiling.$(mode) %s", module.sourcefile)
+                _compile_objectfile_step(target, module, {batchcmds = batchcmds})
+            else
+                batchcmds:rm(module.objectfile) -- force rebuild for .cpp files
+            end
+        end
+        batchcmds:add_depfiles(module.sourcefile)
+    end
+    return os.mtime(module.objectfile)
+end
+
+-- build headerunit file for batchjobs / jobgraph
+function make_headerunit_job(target, headerunit, opt)
+
+    local build = should_build(target, headerunit)
+    if build then
+        local name = headerunit.unique and path.filename(headerunit.name) or headerunit.name
+        progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), name)
+        _compile(target, _make_headerunitflags(target, headerunit), headerunit.sourcefile, headerunit.bmifile)
     end
 end
 
 -- build headerunit file for batchcmds
-function make_headerunit_buildcmds(target, batchcmds, headerunit, bmifile, outputdir, opt)
-    batchcmds:mkdir(outputdir)
-    add_headerunit_to_target_mapper(target, headerunit, bmifile)
+function make_headerunit_buildcmds(target, batchcmds, headerunit, opt)
 
-    if opt.build then
-        local headerfile = headerunit.unique and headerunit.name or headerunit.path
-        batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s"
-            , target:fullname(), headerfile)
-        _batchcmds_compile(batchcmds, target, _make_headerunitflags(target, headerunit, bmifile), bmifile)
+    local compinst = compiler.load("cxx", {target = target})
+    local compflags = compinst:compflags({sourcefile = headerunit.sourcefile, target = target, sourcekind = "cxx"})
+    local depvalues = {compinst:program(), compflags}
+
+    local build = should_build(target, headerunit)
+    if build then
+        local name = headerunit.unique and path.filename(headerunit.name) or headerunit.name
+        batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), name)
+        _batchcmds_compile(batchcmds, target, table.join(_make_headerunitflags(target, headerunit)), headerunit.sourcefile, headerunit.bmifile)
+        batchcmds:add_depfiles(headerunit.sourcefile)
     end
-    batchcmds:add_depfiles(headerunit.path)
-    return os.mtime(bmifile)
+    batchcmds:add_depvalues(depvalues)
 end
 
 function get_requires(target, module)
+
     local _requires
     local flags = _get_requiresflags(target, module)
     for _, flag in ipairs(flags) do

--- a/xmake/rules/c++/modules/clang/scanner.lua
+++ b/xmake/rules/c++/modules/clang/scanner.lua
@@ -27,22 +27,26 @@ import("utils.progress")
 import("support")
 import(".scanner", {inherit = true})
 
-function generate_dependency_for(target, sourcefile, opt)
+-- scan module dependencies
+function scan_dependency_for(target, sourcefile, opt)
+
     local compinst = target:compiler("cxx")
     local changed = false
     local dependfile = target:dependfile(sourcefile)
-    local flags = compinst:compflags({sourcefile = sourcefile, target = target}) or {}
-    local fileconfig = target:fileconfig(sourcefile)
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
 
     depend.on_changed(function()
-        if opt.progress then
+        if opt.progress and not target:data("in_project_generator") then
             progress.show(opt.progress, "${color.build.target}<%s> generating.module.deps %s", target:fullname(), sourcefile)
         end
 
-        local outputdir = support.get_outputdir(target, sourcefile)
+        local outputdir = support.get_outputdir(target, sourcefile, {scan = true})
         local jsonfile = path.translate(path.join(outputdir, path.filename(sourcefile) .. ".json"))
         local has_clangscandepssupport = support.has_clangscandepssupport(target)
-        if has_clangscandepssupport and not target:policy("build.c++.clang.fallbackscanner") then
+        local fallbackscanner = target:policy("build.c++.modules.fallbackscanner") or
+                                target:policy("build.c++.modules.clang.fallbackscanner") or
+                                target:policy("build.c++.clang.fallbackscanner")
+        if has_clangscandepssupport and not fallbackscanner then
             -- We need absolute path of clang to use clang-scan-deps
             -- See https://clang.llvm.org/docs/StandardCPlusPlusModules.html#possible-issues-failed-to-find-system-headers
             local clang_path = compinst:program()
@@ -51,7 +55,7 @@ function generate_dependency_for(target, sourcefile, opt)
             end
             local clangscandeps = support.get_clang_scan_deps(target)
             local dependency_flags = table.join({"--format=p1689", "--",
-                                                 clang_path, "-x", "c++", "-c", sourcefile, "-o", target:objectfile(sourcefile)}, flags)
+                                                 clang_path, "-x", "c++"}, compflags, {"-c", sourcefile, "-o", target:objectfile(sourcefile)})
             if option.get("verbose") then
                 print(os.args(table.join(clangscandeps, dependency_flags)))
             end
@@ -65,11 +69,11 @@ function generate_dependency_for(target, sourcefile, opt)
             end
             fallback_generate_dependencies(target, jsonfile, sourcefile, function(file)
                 local keepsystemincludesflag = support.get_keepsystemincludesflag(target)
-                local compflags = table.clone(flags)
+                local compflags = table.clone(compflags)
                 -- exclude -fmodule* and -std=c++/gnu++* flags because
                 -- when they are set clang try to find bmi of imported modules but they don't exists in this point of compilation
                 table.remove_if(compflags, function(_, flag)
-                    return flag:startswith("-fmodule") or flag:startswith("-std=c++") or flag:startswith("-std=gnu++")
+                    return flag:startswith("-fmodule") or flag:startswith("-fvisibility") or flag:startswith("-std=c++") or flag:startswith("-std=gnu++")
                 end)
                 local ifile = path.translate(path.join(outputdir, path.filename(file) .. ".i"))
                 compflags = table.join(compflags or {}, keepsystemincludesflag or {}, {"-E", "-x", "c++", file, "-o", ifile})
@@ -83,7 +87,7 @@ function generate_dependency_for(target, sourcefile, opt)
 
         local rawdependinfo = io.readfile(jsonfile)
         return {moduleinfo = rawdependinfo}
-    end, {dependfile = dependfile, files = {sourcefile}, changed = target:is_rebuilt(), values = flags})
+    end, {dependfile = dependfile, files = {sourcefile}, changed = target:is_rebuilt(), values = compflags})
     return changed
 end
 

--- a/xmake/rules/c++/modules/config.lua
+++ b/xmake/rules/c++/modules/config.lua
@@ -1,0 +1,92 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      ruki, Arthapz
+-- @file        config.lua
+--
+
+import("core.project.project")
+import("core.base.semver")
+import("support")
+
+function main(target)
+
+    if support.contains_modules(target) then
+        -- when jobgraph is policy is set to false, we disable to build across targets in parallel, because the source files may depend on other target modules
+        -- @see https://github.com/xmake-io/xmake/issues/1858
+        -- @note this will cause cross-parallel builds to be disabled for all sub-dependent targets,
+        -- even if some sub-targets do not contain C++ modules.
+        if not target:policy("build.jobgraph") or target:data("in_project_generator") then
+            target:set("policy", "build.fence", true)
+        end
+
+        assert(not target:rule("c++.unity_build"), "C++ unity build is not compatible with C++ modules")
+
+        -- disable ccache for this target
+        --
+        -- Caching can affect incremental compilation, for example
+        -- by interfering with the results of depfile generation for msvc.
+        --
+        -- @see https://github.com/xmake-io/xmake/issues/3000
+        target:set("policy", "build.ccache", false)
+
+        -- load compiler support
+        support.load(target)
+
+        -- mark this target with modules
+        target:data_set("cxx.has_modules", true)
+
+        -- warn about deprecated policies
+        if target:policy("build.c++.gcc.modules.cxx11abi") then
+            wprint("build.c++.gcc.modules.cxx11abi is deprecated, please use build.c++.modules.gcc.cxx11abi")
+        end
+        if target:policy("build.c++.clang.fallbackscanner") then
+            wprint("build.c++.clang.fallbackscanner is deprecated, please use build.c++.modules.clang.fallbackscanner")
+        end
+        if target:policy("build.c++.gcc.fallbackscanner") then
+            wprint("build.c++.gcc.fallbackscanner is deprecated, please use build.c++.modules.gcc.fallbackscanner")
+        end
+        if target:policy("build.c++.msvc.fallbackscanner") then
+            wprint("build.c++.msvc.fallbackscanner is deprecated, please use build.c++.modules.msvc.fallbackscanner")
+        end
+        if target:policy("build.c++.modules.tryreuse") then
+            wprint("build.c++.modules.tryreuse is deprecated, please use build.c++.modules.reuse")
+        end
+        if target:policy("build.c++.modules.tryreuse.discriminate_on_defines") then
+            wprint("build.c++.modules.tryreuse.discriminate_on_defines is deprecated, please use build.c++.modules.reuse.strict")
+        end
+
+        -- moduleonly modules are implicitly public
+        if target:is_moduleonly() then
+            local sourcebatch = target:sourcebatches()["c++.build.modules.builder"]
+            if sourcebatch then
+                for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+                    target:fileconfig_add(sourcefile, {public = true})
+                end
+            end
+        end
+    end
+end
+
+function insert_stdmodules(target)
+
+    if target:data("cxx.has_modules") then
+        -- add std modules to sourcebatch
+        local stdmodules = support.get_stdmodules(target)
+        for _, sourcefile in ipairs(stdmodules) do
+            table.insert(target:sourcebatches()["c++.build.modules.scanner"].sourcefiles, sourcefile)
+            table.insert(target:sourcebatches()["c++.build.modules.builder"].sourcefiles, sourcefile)
+        end
+    end
+end

--- a/xmake/rules/c++/modules/gcc/builder.lua
+++ b/xmake/rules/c++/modules/gcc/builder.lua
@@ -21,6 +21,7 @@
 -- imports
 import("core.base.json")
 import("core.base.option")
+import("core.base.bytes")
 import("core.base.semver")
 import("utils.progress")
 import("private.action.build.object", {alias = "objectbuilder"})
@@ -28,22 +29,25 @@ import("core.tool.compiler")
 import("core.project.config")
 import("core.project.depend")
 import("support")
+import(".mapper")
 import(".builder", {inherit = true})
 
 -- get flags for building a headerunit
-function _make_headerunitflags(target, headerunit, headerunit_mapper)
-    local module_headerflag = support.get_moduleheaderflag(target)
-    local module_onlyflag = support.get_moduleonlyflag(target)
-    local module_mapperflag = support.get_modulemapperflag(target)
-    assert(module_headerflag and module_onlyflag, "compiler(gcc): does not support c++ header units!")
+function _make_headerunitflags(target, headerunit_mapper, headerunit)
 
-    local local_directory = (headerunit.type == ":quote") and {"-I" .. path.directory(path.normalize(headerunit.path))} or {}
-    local headertype = (headerunit.type == ":angle") and "system" or "user"
-    local flags = table.join(local_directory, {module_mapperflag .. headerunit_mapper,
-                                               module_headerflag .. headertype,
-                                               module_onlyflag,
-                                               "-xc++-header"})
-    return flags
+    local module_headerflag = support.get_moduleheaderflag(target)
+    local module_mapperflag = support.get_modulemapperflag(target)
+    assert(module_headerflag, "compiler(gcc): does not support c++ header units!")
+
+    -- local headertype = opt.stl_headerunit and "c++-system-header" or "c++-header"
+    -- local flags = table.join({}, {module_mapperflag .. headerunit_mapper,
+    --                               "-x", headertype})
+    local headertype = (headerunit.method == "include-angle") and "system" or "user"
+    local includedir = headertype == "user" and "-I" .. path.directory(headerunit.sourcefile)
+    return table.join(includedir and {includedir} or {},
+                      {"-x", "c++-" .. headertype .. "-header",
+                      module_mapperflag .. headerunit_mapper,
+                     module_headerflag .. headertype})
 end
 
 -- do compile
@@ -51,8 +55,8 @@ function _compile(target, flags, sourcefile, outputfile)
 
     local dryrun = option.get("dry-run")
     local compinst = target:compiler("cxx")
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local flags = table.join(compflags or {}, flags)
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
+    flags = table.join(compflags or {}, flags)
 
     -- trace
     if option.get("verbose") then
@@ -69,8 +73,8 @@ end
 -- @note we need to use batchcmds:compilev to translate paths in compflags for generator, e.g. -Ixx
 function _batchcmds_compile(batchcmds, target, flags, sourcefile, outputfile)
     local compinst = target:compiler("cxx")
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local flags = table.join("-c", compflags or {}, flags, {"-o", outputfile, sourcefile})
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
+    flags = table.join("-c", compflags or {}, flags, {"-o", outputfile, sourcefile})
     batchcmds:compilev(flags, {compiler = compinst, sourcekind = "cxx"})
 end
 
@@ -80,46 +84,41 @@ function _module_map_cachekey(target)
 end
 
 -- generate a module mapper file for build a headerunit
-function _generate_headerunit_modulemapper_file(module)
-    local mapper_path = os.tmpfile()
+function _generate_headerunit_modulemapper_file(target, headerunit)
+
+    local mapper_path = _get_modulemapper_file(target, headerunit)
     local mapper_file = io.open(mapper_path, "wb")
-    mapper_file:write("root " .. path.unix(os.projectdir()))
-    mapper_file:write("\n")
-    mapper_file:write(mapper_file, path.unix(module.name) .. " " .. path.unix(module.bmifile))
+    mapper_file:write("root " .. path.directory(headerunit.sourcefile) .. "\n")
+    mapper_file:write(mapper_file, path.unix(headerunit.sourcefile) .. " " .. path.unix(path.absolute(headerunit.bmifile)) .. "\n")
     mapper_file:write("\n")
     mapper_file:close()
     return mapper_path
 end
 
 function _get_maplines(target, module)
-    local maplines = {}
-    local m_name, m, _ = support.get_provided_module(module)
-    if m then
-        table.insert(maplines, m_name .. " " .. support.get_bmi_path(m.bmi))
-    end
-    for required, _ in table.orderpairs(module.requires) do
-        local dep_module = get_from_target_mapper(target, required)
-        assert(dep_module, "module dependency %s required for %s not found", required, m_name or module.cppfile)
 
-        local bmifile = dep_module.bmi
-        local mapline
-        -- aliased headerunit
-        if dep_module.aliasof then
-            local aliased = get_from_target_mapper(target, dep_module.aliasof)
-            bmifile = aliased.bmi
-            mapline = path.unix(dep_module.headerunit.path) .. " " .. path.unix(bmifile)
-        -- headerunit
-        elseif dep_module.headerunit then
-            mapline = path.unix(dep_module.headerunit.path) .. " " .. path.unix(bmifile)
-        -- named module
-        else
-            mapline = required .. " " .. path.unix(bmifile)
+    local maplines = {}
+    if module.interface or module.implementation then
+        table.insert(maplines, module.name .. " " .. path.absolute(module.bmifile))
+    end
+    for dep_name, dep_module in table.orderpairs(module.deps) do
+        local key = dep_name
+        if dep_module.headerunit then
+            key = dep_name .. dep_module.key
         end
+        local dep_module_mapped = mapper.get(target, key)
+        assert(dep_module_mapped, "module dependency %s required for %s not found", dep_name, module.name or module.sourcefile)
+        local mapline
+        local name = dep_name
+        if dep_module_mapped.headerunit then
+            name = dep_module_mapped.method == "include-angle" and dep_module_mapped.sourcefile or path.join("./", path.directory(module.sourcefile), dep_name)
+        end
+        mapline = path.unix(name) .. " " .. path.unix(path.absolute(dep_module_mapped.bmifile))
         table.insert(maplines, mapline)
 
         -- append deps
-        if dep_module.opt and dep_module.opt.deps then
-            local deps = _get_maplines(target, {name = dep_module.name, bmi = bmifile, requires = dep_module.opt.deps})
+        if dep_module.deps then
+            local deps = _get_maplines(target, {name = dep_module.name, deps = dep_module.deps, sourcefile = dep_module.sourcefile})
             table.join2(maplines, deps)
         end
     end
@@ -128,14 +127,22 @@ function _get_maplines(target, module)
     return table.unique(maplines)
 end
 
+function _get_modulemapper_file(target, module)
+    return path.join(os.tmpdir(), hash.md5(bytes(target:fullname() .. "/" .. module.sourcefile)), path.filename(module.sourcefile) .. ".mapper.txt")
+end
+
 -- generate a module mapper file for build a module
 -- e.g
 -- /usr/include/c++/11/iostream build/.gens/stl_headerunit/linux/x86_64/release/stlmodules/cache/iostream.gcm
 -- hello build/.gens/stl_headerunit/linux/x86_64/release/rules/modules/cache/hello.gcm
 --
-function _generate_modulemapper_file(target, module, cppfile)
+function _generate_modulemapper_file(target, module)
+
     local maplines = _get_maplines(target, module)
-    local mapper_path = path.join(os.tmpdir(), target:fullname():replace(" ", "_"), name or cppfile:replace(" ", "_"))
+    local mapper_path = _get_modulemapper_file(target, module)
+    if os.isfile(mapper_path) then
+        os.rm(mapper_path)
+    end
     local mapper_content = {}
     table.insert(mapper_content, "root " .. path.unix(os.projectdir()))
     for _, mapline in ipairs(maplines) do
@@ -148,322 +155,156 @@ function _generate_modulemapper_file(target, module, cppfile)
     return mapper_path
 end
 
--- populate module map
-function populate_module_map(target, modules)
-    for _, module in pairs(modules) do
-        local name, provide = support.get_provided_module(module)
-        if provide then
-            local bmifile = support.get_bmi_path(provide.bmi)
-            add_module_to_target_mapper(target, name, provide.sourcefile, bmifile, {deps = module.requires})
-        end
-    end
-end
+-- build module file for batchjobs / jobgraph
+function make_module_job(target, module, opt)
 
--- get defines for a module
-function get_module_required_defines(target, sourcefile)
-    local compinst = compiler.load("cxx", {target = target})
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local defines
-    for _, flag in ipairs(compflags) do
-        if flag:startswith("-D") then
-            defines = defines or {}
-            table.insert(defines, flag:sub(3))
-        end
-    end
-    return defines
-end
-
--- build module file for batchjobs
-function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
-
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
     local module_mapperflag = support.get_modulemapperflag(target)
-
-    return {
-        name = job_name,
-        deps = table.join(target:fullname() .. "/module/populate_module_map", deps),
-        sourcefile = opt.cppfile,
-        job = batchjobs:newjob(target:fullname() .. "/module/" .. (name or opt.cppfile), function(index, total, jobopt)
-            local mapped_bmi
-            if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-                mapped_bmi = get_from_target_mapper(target, name).bmi
-            end
-
-            -- generate and append module mapper file
-            local module_mapper
-            if provide or opt.module.requires then
-                module_mapper = _generate_modulemapper_file(target, opt.module, opt.cppfile)
-                target:fileconfig_add(opt.cppfile, {force = {cxxflags = {module_mapperflag .. module_mapper}}})
-            end
-
-            local dependfile = target:dependfile(bmifile or opt.objectfile)
-            local build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-
-            -- needed to detect rebuild of dependencies
-            if provide and build then
-                mark_build(target, name)
-            end
-
-            if build then
-                -- compile if it's a named module
-                if provide or support.has_module_extension(opt.cppfile) then
-                    local fileconfig = target:fileconfig(opt.cppfile)
-                    local public = fileconfig and fileconfig.public
-                    local external = fileconfig and fileconfig.external
-                    local from_moduleonly = external and external.moduleonly
-                    local bmifile = mapped_bmi or bmifile
-                    local flags = {"-x", "c++"}
-                    local sourcefile
-                    if external and not from_moduleonly then
-                        if not mapped_bmi then
-                            progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                            local module_onlyflag = support.get_moduleonlyflag(target)
-                            table.insert(flags, module_onlyflag)
-                            sourcefile = opt.cppfile
-                        end
-                    else
-                        progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-                        sourcefile = opt.cppfile
-                    end
-                    if option.get("diagnosis") then
-                        print("mapper file --------\n%s--------", io.readfile(module_mapper))
-                    end
-                    if sourcefile then
-                        _compile(target, flags, sourcefile, opt.objectfile)
-                    end
-                    os.tryrm(module_mapper)
-                else
-                    os.tryrm(opt.objectfile) -- force rebuild for .cpp files
-                end
-                depend.save(dependinfo, dependfile)
-            end
-        end)}
-end
-
--- build module file for jobgraph
-function make_module_jobgraph(target, jobgraph, opt)
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-    local module_mapperflag = support.get_modulemapperflag(target)
-
-    local jobname = target:fullname() .. "/module/" .. (name or opt.cppfile)
-    jobgraph:add(jobname, function(index, total, jobopt)
-        local mapped_bmi
-        if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-            mapped_bmi = get_from_target_mapper(target, name).bmi
-        end
-
-        -- generate and append module mapper file
-        local module_mapper
-        if provide or opt.module.requires then
-            module_mapper = _generate_modulemapper_file(target, opt.module, opt.cppfile)
-            target:fileconfig_add(opt.cppfile, {force = {cxxflags = {module_mapperflag .. module_mapper}}})
-        end
-
-        local dependfile = target:dependfile(bmifile or opt.objectfile)
-        local build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-
-        -- needed to detect rebuild of dependencies
-        if provide and build then
-            mark_build(target, name)
-        end
-
-        if build then
-            -- compile if it's a named module
-            if provide or support.has_module_extension(opt.cppfile) then
-                local fileconfig = target:fileconfig(opt.cppfile)
-                local public = fileconfig and fileconfig.public
-                local external = fileconfig and fileconfig.external
-                local from_moduleonly = external and external.moduleonly
-                local bmifile = mapped_bmi or bmifile
-                local flags = {"-x", "c++"}
-                local sourcefile
-                if external and not from_moduleonly then
-                    if not mapped_bmi then
-                        progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                        local module_onlyflag = support.get_moduleonlyflag(target)
-                        table.insert(flags, module_onlyflag)
-                        sourcefile = opt.cppfile
-                    end
-                else
-                    progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-                    sourcefile = opt.cppfile
-                end
-                if option.get("diagnosis") then
-                    print("mapper file --------\n%s--------", io.readfile(module_mapper))
-                end
-                if sourcefile then
-                    _compile(target, flags, sourcefile, opt.objectfile)
-                end
-                os.tryrm(module_mapper)
-            else
-                os.tryrm(opt.objectfile) -- force rebuild for .cpp files
-            end
-            depend.save(dependinfo, dependfile)
-        end
-    end)
-end
-
--- build module file for batchcmds
-function make_module_buildcmds(target, batchcmds, opt)
-
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-    local module_mapperflag = support.get_modulemapperflag(target)
-
-    local mapped_bmi
-    if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-        mapped_bmi = get_from_target_mapper(target, name).bmi
-    end
+    local module_onlyflag = support.get_moduleonlyflag(target)
+    local module_flag = support.get_modulesflag(target)
+    local dryrun = option.get("dry-run")
 
     -- generate and append module mapper file
     local module_mapper
-    if provide or opt.module.requires then
-        module_mapper = _generate_modulemapper_file(target, opt.module, opt.cppfile)
-        target:fileconfig_add(opt.cppfile, {force = {cxxflags = {module_mapperflag .. module_mapper}}})
+    if module.deps then
+        module_mapper = _get_modulemapper_file(target, module)
+        target:fileconfig_add(module.sourcefile, {force = {cxxflags = {module_mapperflag .. module_mapper}}})
     end
 
-    -- compile if it's a named module
-    if provide or support.has_module_extension(opt.cppfile) then
-        batchcmds:mkdir(path.directory(opt.objectfile))
-        local fileconfig = target:fileconfig(opt.cppfile)
-        local public = fileconfig and fileconfig.public
-        local external = fileconfig and fileconfig.external
-        local from_moduleonly = external and external.moduleonly
-        local bmifile = mapped_bmi or bmifile
+    local build = should_build(target, module)
+    local bmi = opt and opt.bmi
+    local objectfile = opt and opt.objectfile
+
+    if build then
+        if not dryrun then
+            local objectdir = path.directory(module.objectfile)
+            if not os.isdir(objectdir) then
+                os.mkdir(objectdir)
+            end
+            if module.bmifile then
+                local bmidir = path.directory(module.bmifile)
+                if not os.isdir(bmidir) then
+                    os.mkdir(bmidir)
+                end
+            end
+        end
+
+        if module.deps then
+            _generate_modulemapper_file(target, module)
+        end
+
         local flags = {"-x", "c++"}
-        local sourcefile
-        if external and not from_moduleonly then
-            if not mapped_bmi then
-                batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                local module_onlyflag = support.get_moduleonlyflag(target)
+        if module.interface or module.implementation then
+            if bmi and objectfile then
+                progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), module.name)
+                table.insert(flags, module_flag)
+            elseif bmi then
+                progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.bmi.$(mode) %s", target:fullname(), module.name)
+                table.insert(flags, module_flag)
                 table.insert(flags, module_onlyflag)
-                sourcefile = opt.cppfile
+            else
+                progress.show(opt.progress, "compiling.$(mode) %s", module.sourcefile)
             end
+            _compile(target, flags, module.sourcefile, module.objectfile)
+            -- os.tryrm(module_mapper) -- force rebuild for .cpp files
         else
-            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-            sourcefile = opt.cppfile
+            os.tryrm(module.objectfile) -- force rebuild for .cpp files
         end
+    end
+end
+
+-- build module file for batchcmds
+function make_module_buildcmds(target, batchcmds, module, opt)
+
+    local module_mapperflag = support.get_modulemapperflag(target)
+    local module_onlyflag = support.get_moduleonlyflag(target)
+    local module_flag = support.get_modulesflag(target)
+
+    local module_mapper
+    if module.implementation or module.interface or module.deps then
+        module_mapper = _get_modulemapper_file(target, module)
+        target:fileconfig_add(module.sourcefile, {force = {cxxflags = {module_mapperflag .. module_mapper}}})
+    end
+
+    -- generate and append module mapper file
+    local build = should_build(target, module)
+
+    local fileconfig = target:fileconfig(module.sourcefile)
+    local external = fileconfig and fileconfig.external
+    local bmionly = external and external.bmionly
+    local reused = external and external.reused
+    if build and not reused then
+        if module.implementation or module.interface or module.deps then
+            _generate_modulemapper_file(target, module)
+        end
+
         if option.get("diagnosis") then
-            batchcmds:print("mapper file: %s", io.readfile(module_mapper))
-        end
-        if sourcefile then
-            _batchcmds_compile(batchcmds, target, flags, sourcefile, opt.objectfile)
-        end
-        batchcmds:rm(module_mapper)
-    else
-        batchcmds:rm(opt.objectfile) -- force rebuild for .cpp files
-    end
-    batchcmds:add_depfiles(opt.cppfile)
-    return os.mtime(opt.objectfile)
-end
-
--- build headerunit file for batchjobs
-function make_headerunit_buildjobs(target, job_name, batchjobs, headerunit, bmifile, outputdir, opt)
-    local _headerunit = headerunit
-    _headerunit.path = headerunit.type == ":quote" and "./" .. path.relative(headerunit.path) or headerunit.path
-    local already_exists = add_headerunit_to_target_mapper(target, _headerunit, bmifile)
-    if not already_exists then
-        return {
-            name = job_name,
-            sourcefile = headerunit.path,
-            job = batchjobs:newjob(job_name, function(index, total, jobopt)
-                if not os.isdir(outputdir) then
-                    os.mkdir(outputdir)
-                end
-
-                local compinst = compiler.load("cxx", {target = target})
-                local compflags = compinst:compflags({sourcefile = headerunit.path, target = target})
-
-                local dependfile = target:dependfile(bmifile)
-                local dependinfo = depend.load(dependfile) or {}
-                dependinfo.files = {}
-                local depvalues = {compinst:program(), compflags}
-
-                if opt.build then
-                    local headerunit_mapper = _generate_headerunit_modulemapper_file({name = path.normalize(headerunit.path), bmifile = bmifile})
-                    progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), headerunit.name)
-                    if option.get("diagnosis") then
-                        print("mapper file:\n%s", io.readfile(headerunit_mapper))
-                    end
-                    local headerfile = headerunit.unique and headerunit.name or headerunit.path
-                    _compile(target,
-                        _make_headerunitflags(target, headerunit, headerunit_mapper, opt),
-                        path.translate(headerfile), bmifile)
-                    os.tryrm(headerunit_mapper)
-                end
-
-                table.insert(dependinfo.files, headerunit.path)
-                dependinfo.values = depvalues
-                depend.save(dependinfo, dependfile)
-            end)}
-    end
-end
-
--- build headerunit file for jobgraph
-function make_headerunit_jobgraph(target, job_name, jobgraph, headerunit, bmifile, outputdir, opt)
-    local _headerunit = headerunit
-    _headerunit.path = headerunit.type == ":quote" and "./" .. path.relative(headerunit.path) or headerunit.path
-    local already_exists = add_headerunit_to_target_mapper(target, _headerunit, bmifile)
-    if not already_exists then
-        jobgraph:add(job_name, function(index, total, jobopt)
-            if not os.isdir(outputdir) then
-                os.mkdir(outputdir)
+            if module.name  then
+                batchcmds:show("mapper file for %s (%s) --------\n%s--------", module.name, module.sourcefile, io.readfile(module_mapper))
+            else
+                batchcmds:show("mapper file for %s --------\n%s--------", module.sourcefile, io.readfile(module_mapper))
             end
-
-            local compinst = compiler.load("cxx", {target = target})
-            local compflags = compinst:compflags({sourcefile = headerunit.path, target = target})
-
-            local dependfile = target:dependfile(bmifile)
-            local dependinfo = depend.load(dependfile) or {}
-            dependinfo.files = {}
-            local depvalues = {compinst:program(), compflags}
-
-            if opt.build then
-                local headerunit_mapper = _generate_headerunit_modulemapper_file({name = path.normalize(headerunit.path), bmifile = bmifile})
-                progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s",
-                    target:fullname(), headerunit.name)
-                if option.get("diagnosis") then
-                    print("mapper file:\n%s", io.readfile(headerunit_mapper))
-                end
-                local headerfile = headerunit.unique and headerunit.name or headerunit.path
-                _compile(target,
-                    _make_headerunitflags(target, headerunit, headerunit_mapper, opt),
-                    path.translate(headerfile), bmifile)
-                os.tryrm(headerunit_mapper)
+        end
+        if support.has_module_extension(module.sourcefile) then
+            batchcmds:mkdir(path.directory(module.objectfile))
+            local flags = {"-x", "c++"}
+            table.insert(flags, module_flag)
+            local name = module.name or module.sourcefile
+            if bmionly then
+                batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.bmi.$(mode) %s", target:fullname(), name)
+                table.insert(flags, module_onlyflag)
+            else
+                batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name)
             end
-
-            table.insert(dependinfo.files, headerunit.path)
-            dependinfo.values = depvalues
-            depend.save(dependinfo, dependfile)
-        end)
+            _batchcmds_compile(batchcmds, target, flags, module.sourcefile, module.objectfile)
+            batchcmds:rm(module_mapper)
+        else
+            batchcmds:rm(module.objectfile) -- force rebuild for .cpp files
+        end
+        batchcmds:add_depfiles(module.sourcefile)
+        support.memcache():set2(target:fullname(), "has_built_" .. module.sourcefile, true)
     end
+    return os.mtime(module.objectfile)
 end
 
+-- build headerunit file for batchjobs / jobgraph
+function make_headerunit_job(target, headerunit, opt)
 
+    local build = should_build(target, headerunit)
+    if build then
+        local headerunit_mapper = _generate_headerunit_modulemapper_file(target, headerunit)
+        local name = headerunit.unique and path.filename(headerunit.sourcefile) or headerunit.name
+        if option.get("diagnosis") then
+            print("mapper file for %s (%s) --------\n%s--------", name, headerunit_mapper, io.readfile(headerunit_mapper))
+        end
+        progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), name)
+        _compile(target,
+                 _make_headerunitflags(target, headerunit_mapper, headerunit),
+                 path.filename(headerunit.sourcefile), headerunit.bmifile)
+        os.tryrm(headerunit_mapper)
+    end
+end
 
 -- build headerunit file for batchcmds
-function make_headerunit_buildcmds(target, batchcmds, headerunit, bmifile, outputdir, opt)
-    local headerunit_mapper = _generate_headerunit_modulemapper_file({name = path.normalize(headerunit.path), bmifile = bmifile})
-    batchcmds:mkdir(outputdir)
+function make_headerunit_buildcmds(target, batchcmds, headerunit, opt)
 
-    local _headerunit = headerunit
-    _headerunit.path = headerunit.type == ":quote" and "./" .. path.relative(headerunit.path) or headerunit.path
-    add_headerunit_to_target_mapper(target, _headerunit, bmifile)
+    local compinst = compiler.load("cxx", {target = target})
+    local compflags = compinst:compflags({sourcefile = headerunit.sourcefile, target = target, sourcekind = "cxx"})
+    local depvalues = {compinst:program(), compflags}
 
-    if opt.build then
-        local headerfile = headerunit.unique and headerunit.name or headerunit.path
-        batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s",
-            target:fullname(), headerfile)
+    local build = should_build(target, headerunit)
+    if build then
+        local headerunit_mapper = _generate_headerunit_modulemapper_file(target, headerunit)
+        local name = headerunit.unique and path.filename(headerunit.name) or headerunit.name
         if option.get("diagnosis") then
-            batchcmds:print("mapper file:\n%s", io.readfile(headerunit_mapper))
+            batchcmds:show("mapper file for %s (%s) --------\n%s--------", name, headerunit_mapper, io.readfile(headerunit_mapper))
         end
-        _batchcmds_compile(batchcmds, target, _make_headerunitflags(target, headerunit, headerunit_mapper), bmifile)
+        batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), name)
+        _batchcmds_compile(batchcmds, target,
+                     _make_headerunitflags(target, headerunit_mapper, headerunit),
+                     path.filename(headerunit.sourcefile), headerunit.bmifile)
+        batchcmds:add_depfiles(headerunit.sourcefile)
+        batchcmds:rm(headerunit_mapper)
     end
-
-    batchcmds:rm(headerunit_mapper)
-    batchcmds:add_depfiles(headerunit.path)
-    return os.mtime(bmifile)
+    batchcmds:add_depvalues(depvalues)
 end
 

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -33,6 +33,7 @@ import(".support", {inherit = true})
 -- # 59 "/usr/include/c++/11/vector" 3
 --
 function _get_toolchain_includedirs_for_stlheaders(includedirs, gcc)
+
     local tmpfile = os.tmpfile() .. ".cc"
     io.writefile(tmpfile, "#include <vector>")
     local result = try {function () return os.iorunv(gcc, {"-E", "-x", "c++", tmpfile}) end}
@@ -53,57 +54,62 @@ end
 
 -- load module support for the current target
 function load(target)
+
     local modulesflag = get_modulesflag(target)
     target:add("cxxflags", modulesflag, {force = true, expand = false})
 
     -- fix cxxabi issue
     -- @see https://github.com/xmake-io/xmake/issues/2716#issuecomment-1225057760
     -- https://github.com/xmake-io/xmake/issues/3855
-
-    if target:policy("build.c++.gcc.modules.cxx11abi") then
+    local cxx11abi = target:policy("build.c++.modules.gcc.cxx11abi") or
+                     target:policy("build.c++.gcc.modules.cxx11abi")
+     
+    if cxx11abi then
         target:add("cxxflags", "-D_GLIBCXX_USE_CXX11_ABI=1")
     else
         target:add("cxxflags", "-D_GLIBCXX_USE_CXX11_ABI=0")
     end
 end
 
--- strip flags that doesn't affect bmi generation
-function strip_flags(target, flags)
-    -- speculative list as there is no resource that list flags that prevent reusability, this list will likely be improve over time
-    local strippable_flags = {
-        "-I",
-        "-isystem",
-        "-g",
-        "-O",
-        "-W",
-        "-w",
-        "-cxx-isystem",
-        "-Q",
-        "-fmodule-mapper",
-    }
-    if not target:policy("build.c++.modules.tryreuse.discriminate_on_defines") then
-        table.join2(strippable_flags, {"-D", "-U"})
-    end
+function has_two_phase_compilation_support(_)
+    return false
+end
+
+-- strip module mapper flag
+function strip_mapper_flag(flags)
+
     local output = {}
-    local last_flag_I = false
     for _, flag in ipairs(flags) do
-        local strip = false
-        for _, _flag in ipairs(strippable_flags) do
-            if flag:startswith(_flag) or last_flag_I then
-                last_flag_I = _flag == "-I"
-                strip = true
-                break
-            end
-        end
-        if not strip then
+        if not flag:startswith("-fmodule-mapper") then
             table.insert(output, flag)
         end
     end
     return output
 end
 
+-- flags that doesn't affect bmi generation
+function strippeable_flags()
+
+    -- speculative list as there is no resource that list flags that prevent reusability, this list will likely be improve over time
+    local strippeable_flags = {
+        "-O",
+        "-W",
+        "-w",
+        "-Q",
+        "-fmodule-mapper",
+        "-fmodules-ts"
+    }
+    local splitted_strippeable_flags = {
+        "-I",
+        "-isystem",
+        "-cxx-isystem",
+    }
+    return strippeable_flags, splitted_strippeable_flags
+end
+
 -- provide toolchain include directories for stl headerunit when p1689 is not supported
 function toolchain_includedirs(target)
+
     local includedirs = _g.includedirs
     if includedirs == nil then
         includedirs = {}
@@ -135,20 +141,19 @@ function get_target_module_mapperpath(target)
 end
 
 function _get_std_module_manifest_path(target)
+
     local compinst = target:compiler("cxx")
     local modules_json_path, _ = try {
         function()
             return os.iorunv(compinst:program(), {"-print-file-name=libstdc++.modules.json"}, {envs = compinst:runenvs()})
         end
     }
-
     if modules_json_path then
         modules_json_path = modules_json_path:trim()
         if os.isfile(modules_json_path) then
             return modules_json_path
         end
     end
-
     -- fallback on custom detection
     -- manifest can be found alongside libstdc++.so
 
@@ -156,15 +161,14 @@ function _get_std_module_manifest_path(target)
 end
 
 function get_stdmodules(target)
+
     if not target:policy("build.c++.modules.std") then
         return
     end
-
     local modules_json_path = _get_std_module_manifest_path(target)
     if not modules_json_path then
         return
     end
-
     local modules_json = json.loadfile(modules_json_path)
     if modules_json and modules_json.modules and #modules_json.modules > 0 then
         local std_module_files = {}
@@ -185,6 +189,7 @@ function get_bmi_extension()
 end
 
 function get_modulesflag(target)
+
     local modulesflag = _g.modulesflag
     if modulesflag == nil then
         local compinst = target:compiler("cxx")
@@ -206,6 +211,7 @@ function get_modulesflag(target)
 end
 
 function get_moduleheaderflag(target)
+
     local moduleheaderflag = _g.moduleheaderflag
     if moduleheaderflag == nil then
         -- we need to suppress warnings/errors:
@@ -221,6 +227,7 @@ function get_moduleheaderflag(target)
 end
 
 function get_moduleonlyflag(target)
+
     local moduleonlyflag = _g.moduleonlyflag
     if moduleonlyflag == nil then
         local compinst = target:compiler("cxx")
@@ -233,6 +240,7 @@ function get_moduleonlyflag(target)
 end
 
 function get_modulemapperflag(target)
+
     local modulemapperflag = _g.modulemapperflag
     if modulemapperflag == nil then
         local compinst = target:compiler("cxx")
@@ -246,6 +254,7 @@ function get_modulemapperflag(target)
 end
 
 function get_depsflag(target)
+
     local depflag = _g.depflag
     if depflag == nil then
         local compinst = target:compiler("cxx")
@@ -264,6 +273,7 @@ function get_depsflag(target)
 end
 
 function get_depsfileflag(target)
+
     local depfileflag = _g.depfileflag
     if depfileflag == nil then
         local compinst = target:compiler("cxx")
@@ -282,6 +292,7 @@ function get_depsfileflag(target)
 end
 
 function get_depstargetflag(target)
+
     local depoutputflag = _g.depoutputflag
     if depoutputflag == nil then
         local compinst = target:compiler("cxx")
@@ -300,6 +311,7 @@ function get_depstargetflag(target)
 end
 
 function get_cppversionflag(target)
+
     local cppversionflag = _g.cppversionflag
     if cppversionflag == nil then
         local compinst = target:compiler("cxx")
@@ -311,6 +323,7 @@ function get_cppversionflag(target)
 end
 
 function get_gcc_version(target)
+
     local gcc_version = _g.gcc_version
     if not gcc_version then
         local program, toolname = target:tool("cxx")

--- a/xmake/rules/c++/modules/install.lua
+++ b/xmake/rules/c++/modules/install.lua
@@ -1,0 +1,41 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      ruki, Arthapz
+-- @file        install.lua
+--
+
+import("support")
+import("scanner")
+import("builder")
+
+function install(target)
+    -- we cannot use target:data("cxx.has_modules"),
+    -- because on_config will be not called when installing targets
+    if support.contains_modules(target) then
+        local modules = scanner.get_modules(target)
+        builder.generate_metadata(target, modules)
+        support.add_installfiles_for_modules(target, modules)
+    end
+end
+
+function uninstall(target)
+    import("support")
+    if support.contains_modules(target) then
+        local modules = scanner.get_modules(target)
+        support.add_installfiles_for_modules(target, modules)
+    end
+end

--- a/xmake/rules/c++/modules/mapper.lua
+++ b/xmake/rules/c++/modules/mapper.lua
@@ -1,0 +1,125 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      ruki, Arthapz
+-- @file        mapper.lua
+--
+
+import("support")
+import("core.base.hashset")
+
+-- get or create a target module mapper
+function get_mapper_for(target, opt)
+
+    local localcache = support.localcache()
+    local mapper = localcache:get2(target:fullname(), "module_mapper")
+    local invalidate = opt and opt.invalidate
+    if not mapper or invalidate then
+        mapper = {}
+        localcache:set2(target:fullname(), "module_mapper", mapper)
+    end
+    return mapper
+end
+
+function reuse_modules(target)
+
+    local localcache = support.localcache()
+    local reused_modules = localcache:get2(target:fullname(), "reused_modules")
+    for key, from_name in pairs(reused_modules) do
+        local dep = target:dep(from_name)
+        assert(dep)
+        support.set_reused(target, dep, key)
+    end
+end
+
+-- feed the module mapper
+function feed(target, modules, sourcefiles)
+
+    local mapper = get_mapper_for(target, {invalidate = true})
+    local localcache = support.localcache()
+    local deps_names = hashset.new()
+    local deps_names_map = {}
+    local headerunit_aliases = {}
+    for _, module in pairs(modules) do
+        if module.headerunit and module.alias then
+            table.insert(headerunit_aliases, module)
+        elseif not module.sourcealias then
+            local name = module.headerunit and (module.name .. module.key) or module.name
+            if name then
+                if name ~= "std" and name ~= "std.compat" and deps_names:has(name) then
+                    raise("duplicate module name detected for \"" .. name .. "\"\n  <" .. target:fullname() .. "> -> " .. module.sourcefile .. "\n  <" .. deps_names_map[name] .. "> -> " .. mapper[name].sourcefile)
+                end
+                deps_names:insert(module.name)
+                deps_names_map[name] = target:fullname()
+                if module.headerunit then
+                    if not mapper[name] then
+                        mapper[name] = module
+                    end
+                else
+                    mapper[name] = module
+                end
+            end
+            if not module.headerunit and not mapper[module.sourcefile] then
+                mapper[module.sourcefile] = table.clone(module)
+                mapper[module.sourcefile].sourcealias = true
+            end
+        end
+    end
+    local reuse = target:policy("build.c++.modules.reuse") or
+                  target:policy("build.c++.modules.tryreuse")
+    -- replace target reused module by dep module
+    if reuse then
+        for _, sourcefile in ipairs(sourcefiles) do
+            local external = support.is_external(target, sourcefile)
+            if external then
+                local reused, from = support.is_reused(target, sourcefile)
+                if reused then
+                    local module = get(from, sourcefile)
+                    mapper[module.name] =  module
+                    for dep_name, dep_module in pairs(module.deps) do
+                        if dep_module.headerunit then
+                            local key = dep_name .. dep_module.key
+                            mapper[key] = get(dep, key)
+                            local sourcefile = mapper[key].sourcefile
+                            mapper[sourcefile .. dep_module.key] = table.clone(mapper[key])
+                            mapper[sourcefile .. dep_module.key].alias = false
+                        end
+                    end
+                end
+            end
+        end
+    end
+    -- insert aliases
+    for _, alias in pairs(headerunit_aliases) do
+        local name = alias.name .. alias.key
+        if not mapper[name] then
+            local _module = table.clone(mapper[alias.sourcefile .. alias.key])
+            _module.name = alias.name
+            _module.alias = true
+            mapper[name] = _module
+        end
+    end
+
+    localcache:save()
+end
+
+-- get a module from target mapper by name
+function get(target, name)
+    local mapper = get_mapper_for(target)
+    assert(mapper)
+    return mapper[name]
+end
+

--- a/xmake/rules/c++/modules/msvc/builder.lua
+++ b/xmake/rules/c++/modules/msvc/builder.lua
@@ -29,77 +29,66 @@ import("core.project.config")
 import("core.project.depend")
 import("private.tools.vstool")
 import("support")
+import(".mapper")
 import(".builder", {inherit = true})
 
 -- get flags for building a module
-function _make_modulebuildflags(target, provide, bmifile, opt)
+function _make_modulebuildflags(target, module, opt)
+
     local ifcoutputflag = support.get_ifcoutputflag(target)
     local ifconlyflag = support.get_ifconlyflag(target)
     local interfaceflag = support.get_interfaceflag(target)
     local internalpartitionflag = support.get_internalpartitionflag(target)
-    local ifconly = (not opt.build_objectfile and ifconlyflag)
+
+    local bmionly = opt and opt.bmionly
 
     local flags
-    if provide then -- named module
-        flags = table.join({"-TP", ifcoutputflag, path(bmifile), provide.interface and interfaceflag or internalpartitionflag}, ifconly or {})
+    if module.interface or module.implementation then -- named module
+        flags = table.join("-TP", module.interface and interfaceflag or internalpartitionflag, bmionly and ifconlyflag or {}, ifcoutputflag, path(module.bmifile))
     else
         flags = {"-TP"}
     end
     return flags
 end
-function _compile_one_step(target, bmifile, sourcefile, objectfile, provide, opt)
-    local ifcoutputflag = support.get_ifcoutputflag(target)
-    local interfaceflag = support.get_interfaceflag(target)
-    local internalpartitionflag = support.get_internalpartitionflag(target)
+
+function _compile_one_step(target, module, opt)
+
     -- get flags
-    local flags = {"-TP"}
-    if provide then
-        table.join2(flags, ifcoutputflag, path(bmifile), provide.interface and interfaceflag or internalpartitionflag)
-    end
+    local flags = _make_modulebuildflags(target, module)
     if opt and opt.batchcmds then
-        _batchcmds_compile(opt.batchcmds, target, flags, sourcefile, objectfile)
+        _batchcmds_compile(opt.batchcmds, target, flags, module.sourcefile, module.objectfile)
     else
-        _compile(target, flags, sourcefile, objectfile)
+        _compile(target, flags, module.sourcefile, module.objectfile)
     end
 end
 
-function _compile_bmi_step(target, bmifile, sourcefile, objectfile, provide, opt)
-    local ifcoutputflag = support.get_ifcoutputflag(target)
-    local interfaceflag = support.get_interfaceflag(target)
-    local ifconlyflag = support.get_ifconlyflag(target)
+function _compile_bmi_step(target, module, opt)
 
+    local ifconlyflag = support.get_ifconlyflag(target)
     if not ifconlyflag then
-        _compile_one_step(target, bmifile, sourcefile, objectfile, provide, opt)
+        _compile_one_step(target, module, opt)
     else
-        local flags = {"-TP", ifcoutputflag, path(bmifile), interfaceflag, ifconlyflag}
+        local flags = _make_modulebuildflags(target, module, {bmionly = true})
         if opt and opt.batchcmds then
-            _batchcmds_compile(opt.batchcmds, target, flags, sourcefile, bmifile)
+            _batchcmds_compile(opt.batchcmds, target, flags, module.sourcefile, module.objectfile)
         else
-            _compile(target, flags, sourcefile, bmifile)
+            _compile(target, flags, module.sourcefile, module.objectfile)
         end
     end
 end
+    
+function _compile_objectfile_step(target, module, opt)
 
-function _compile_objectfile_step(target, bmifile, sourcefile, objectfile, provide, opt)
-    local ifconlyflag = support.get_ifconlyflag(target)
-    local interfaceflag = support.get_interfaceflag(target)
-    local internalpartitionflag = support.get_internalpartitionflag(target)
-
-    local flags = {"-TP", (provide and provide.interface) and interfaceflag or internalpartitionflag}
-    if not ifconlyflag then
-        _compile_one_step(target, bmifile, sourcefile, objectfile, provide, opt)
+    local flags = _make_modulebuildflags(target, module)
+    if opt and opt.batchcmds then
+        _batchcmds_compile(opt.batchcmds, target, flags, module.sourcefile, module.objectfile)
     else
-        if opt and opt.batchcmds then
-            _batchcmds_compile(opt.batchcmds, target, flags, sourcefile, objectfile)
-        else
-            _compile(target, flags, sourcefile, objectfile)
-        end
+        _compile(target, flags, module.sourcefile, module.objectfile)
     end
 end
-
 
 -- get flags for building a headerunit
-function _make_headerunitflags(target, headerunit, bmifile)
+function _make_headerunitflags(target, headerunit, headertype)
 
     -- get flags
     local exportheaderflag = support.get_exportheaderflag(target)
@@ -108,41 +97,35 @@ function _make_headerunitflags(target, headerunit, bmifile)
     local ifconlyflag = support.get_ifconlyflag(target)
     assert(headernameflag and exportheaderflag, "compiler(msvc): does not support c++ header units!")
 
-    local local_directory = (headerunit.type == ":quote") and {"-I" .. path.directory(headerunit.path)} or {}
-    local flags = table.join(local_directory, {"-TP",
-                                               exportheaderflag,
-                                               headernameflag .. headerunit.type,
-                                               headerunit.type == ":angle" and headerunit.name or headerunit.path,
-                                               ifcoutputflag,
-                                               bmifile}, ifconlyflag or {})
+    local flags = {"-TP",
+                   exportheaderflag,
+                   ifcoutputflag,
+                   headerunit.bmifile,
+                   ifconlyflag or {},
+                   headernameflag .. headertype} -- keep it at last flag
     return flags
 end
 
 -- do compile
-function _compile(target, flags, sourcefile, outputfile, headerunit)
+function _compile(target, flags, sourcefile, outputfile)
 
     local dryrun = option.get("dry-run")
     local compinst = target:compiler("cxx")
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local flags = table.join(compflags or {}, flags)
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
+    flags = table.join(compflags or {}, flags or {})
 
     -- trace
     if option.get("verbose") then
-        if headerunit then
-            print(os.args(compinst:program(), flags))
+        if not outputfile then
+            print(os.args(table.join(compinst:program(), flags, sourcefile)))
         else
-            print(compinst:compcmd(sourcefile, outputfile, {target = target, compflags = flags, rawargs = true}))
+            print(compinst:compcmd(sourcefile, outputfile, {target = target, compflags = flags, sourcekind = "cxx", rawargs = true}))
         end
     end
 
     -- do compile
     if not dryrun then
-        if headerunit then
-            local msvc = target:toolchain("msvc")
-            os.vrunv(compinst:program(), flags, {envs = msvc:runenvs()})
-        else
-            assert(compinst:compile(sourcefile, outputfile, {target = target, compflags = flags}))
-        end
+        assert(compinst:compile(sourcefile, outputfile or target:objectfile(sourcefile), {target = target, compflags = flags}))
     end
 end
 
@@ -151,9 +134,9 @@ end
 function _batchcmds_compile(batchcmds, target, flags, sourcefile, outputfile)
     opt = opt or {}
     local compinst = target:compiler("cxx")
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    flags = table.join(compflags or {}, flags)
-    batchcmds:compile(sourcefile, outputfile, {sourcekind = "cxx", compflags = flags})
+    local compflags = compinst:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
+    flags = table.join("/c", compflags or {}, outputfile and "-Fo" .. outputfile or {}, flags or {}, sourcefile or {})
+    batchcmds:compilev(flags, {compiler = compinst, sourcekind = "cxx"})
 end
 
 -- get module requires flags
@@ -161,41 +144,40 @@ end
 -- /reference Foo=build/.gens/Foo/rules/modules/cache/Foo.ifc
 -- /headerUnit:angle glm/mat4x4.hpp=Users\arthu\AppData\Local\.xmake\packages\g\glm\0.9.9+8\91454f3ee0be416cb9c7452970a2300f\include\glm\mat4x4.hpp.ifc
 --
-function _get_requiresflags(target, module, opt)
+function _get_requiresflags(target, module)
 
     local referenceflag = support.get_referenceflag(target)
     local headerunitflag = support.get_headerunitflag(target)
 
-    local name = module.name
+    local name = module.name or module.sourcefile
     local cachekey = target:fullname() .. name
 
     local requires, requires_changed = is_dependencies_changed(target, module)
     local requiresflags = support.memcache():get2(cachekey, "requiresflags")
     if not requiresflags or requires_changed then
         local deps_flags = {}
-        for required in requires:orderitems() do
-            local dep_module = get_from_target_mapper(target, required)
+        for required, dep in pairs(module.deps) do
+            if dep.headerunit then
+                required = required .. dep.key
+            end
+            local dep_module = mapper.get(target, required)
             assert(dep_module, "module dependency %s required for %s not found <%s>", required, name, target:fullname())
 
-            local mapflag
-            local bmifile = dep_module.bmi
             -- aliased headerunit
-            if dep_module.aliasof then
-                local aliased = get_from_target_mapper(target, dep_module.aliasof)
-                bmifile = aliased.bmi
-                mapflag = {headerunitflag .. aliased.headerunit.type, required .. "=" .. bmifile}
-            -- headerunit
-            elseif dep_module.headerunit then
-                mapflag = {headerunitflag .. dep_module.headerunit.type, required .. "=" .. bmifile}
-            -- named module
+            local mapflag
+            if dep_module.headerunit then
+                local type = dep_module.method == "include-angle" and ":angle" or ":quote"
+                mapflag = {headerunitflag .. type}
+                table.insert(deps_flags, {headerunitflag, dep_module.sourcefile .. "=" .. dep_module.bmifile})
             else
-                mapflag = {referenceflag, required .. "=" .. bmifile}
+                mapflag = {referenceflag}
             end
+            table.insert(mapflag, dep_module.name .. "=" .. dep_module.bmifile)
             table.insert(deps_flags, mapflag)
 
             -- append deps
-            if dep_module.opt and dep_module.opt.deps then
-                local deps = _get_requiresflags(target, { name = dep_module.name or dep_module.sourcefile, bmi = bmifile, requires = dep_module.opt.deps })
+            if dep_module.deps then
+                local deps = _get_requiresflags(target, dep_module)
                 table.join2(deps_flags, deps)
             end
         end
@@ -203,6 +185,7 @@ function _get_requiresflags(target, module, opt)
         -- remove duplicates
         requiresflags = {}
         local contains = {}
+        table.sort(deps_flags, function(a, b) return a[2] > b[2] end)
         for _, map in ipairs(deps_flags) do
             local name = map[2]:split("=")[1]
             if name and not contains[name] then
@@ -216,297 +199,124 @@ function _get_requiresflags(target, module, opt)
     return requiresflags
 end
 
-function _append_requires_flags(target, module, name, cppfile, bmifile, opt)
-    local cxxflags = {}
-    local requiresflags = _get_requiresflags(target, {name = (name or cppfile), bmi = bmifile, requires = module.requires})
-    for _, flag in ipairs(requiresflags) do
-        -- we need to wrap flag to support flag with space
-        if type(flag) == "string" and flag:find(" ", 1, true) then
-            table.insert(cxxflags, {flag})
+function _append_requires_flags(target, module)
+
+    local requiresflags = _get_requiresflags(target, module)
+    target:fileconfig_add(module.sourcefile, {force = {cxxflags = requiresflags}})
+end
+
+function append_requires_flags(target, built_modules)
+
+    -- append requires flags
+    for _, sourcefile in ipairs(built_modules) do
+        local module = mapper.get(target, sourcefile)
+        if module.deps then
+            _append_requires_flags(target, module)
+        end
+    end
+end
+
+-- build module file for batchjobs / jobgraph
+function make_module_job(target, module, opt)
+
+    local dryrun = option.get("dry-run")
+
+    -- generate and append module mapper file
+    local build = should_build(target, module)
+    local bmi = opt and opt.bmi
+    local objectfile = opt and opt.objectfile
+
+    if build then
+        if not dryrun then
+            local objectdir = path.directory(module.objectfile)
+            if not os.isdir(objectdir) then
+                os.mkdir(objectdir)
+            end
+            if module.bmifile then
+                local bmidir = path.directory(module.bmifile)
+                if not os.isdir(bmidir) then
+                    os.mkdir(bmidir)
+                end
+            end
+        end
+
+        if bmi and objectfile then
+            progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), module.name)
+            _compile_one_step(target, module)
+        elseif bmi then
+            progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.bmi.$(mode) %s", target:fullname(), module.name)
+            _compile_bmi_step(target, module)
         else
-            table.insert(cxxflags, flag)
-        end
-    end
-    target:fileconfig_add(cppfile, {force = {cxxflags = cxxflags}})
-end
-
--- populate module map
-function populate_module_map(target, modules)
-    for _, module in pairs(modules) do
-        local name, provide, cppfile = support.get_provided_module(module)
-        if provide then
-            local bmifile = support.get_bmi_path(provide.bmi)
-            add_module_to_target_mapper(target, name, cppfile, bmifile, {deps = module.requires})
-        end
-    end
-end
-
--- get defines for a module
-function get_module_required_defines(target, sourcefile)
-    local compinst = compiler.load("cxx", {target = target})
-    local compflags = compinst:compflags({sourcefile = sourcefile, target = target})
-    local defines
-    for _, flag in ipairs(compflags) do
-        if flag:startswith("-D") or flag:startswith("/D") then
-            defines = defines or {}
-            table.insert(defines, flag:sub(3))
-        end
-    end
-    return defines
-end
-
--- build module file for batchjobs
-function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-    local dryrun = option.get("dry-run")
-
-    return {
-        name = job_name,
-        deps = table.join(target:fullname() .. "/module/populate_module_map", deps),
-        sourcefile = opt.cppfile,
-        job = batchjobs:newjob(target:fullname() .. "/module/" .. (name or opt.cppfile), function(index, total, jobopt)
-
-            local mapped_bmi
-            if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-                mapped_bmi = get_from_target_mapper(target, name).bmi
-            end
-
-            local build, dependinfo
-            local dependfile = target:dependfile(bmifile or opt.objectfile)
-            if provide or support.has_module_extension(opt.cppfile) then
-                build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-
-                -- needed to detect rebuild of dependencies
-                if provide and build then
-                    mark_build(target, name)
-                end
-            end
-
-            -- append requires flags
-            if opt.module.requires then
-                _append_requires_flags(target, opt.module, name, opt.cppfile, bmifile, opt)
-            end
-
-            -- for cpp file we need to check after appendings the flags
-            if build == nil then
-                build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-            end
-
-            if build then
-                -- compile if it's a named module
-                if provide or support.has_module_extension(opt.cppfile) then
-                    if not dryrun then
-                        local objectdir = path.directory(opt.objectfile)
-                        if not os.isdir(objectdir) then
-                            os.mkdir(objectdir)
-                        end
-                    end
-
-                    local fileconfig = target:fileconfig(opt.cppfile)
-                    local public = fileconfig and fileconfig.public
-                    local external = fileconfig and fileconfig.external
-                    local from_moduleonly = external and external.moduleonly
-                    local bmifile = mapped_bmi or bmifile
-                    if external and not from_moduleonly then
-                        if not mapped_bmi then
-                            progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                            _compile_bmi_step(target, bmifile, opt.cppfile, opt.objectfile, provide)
-                        end
-                    else
-                        progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-                        _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, provide)
-                    end
-                else
-                    os.tryrm(opt.objectfile) -- force rebuild for .cpp files
-                end
-                depend.save(dependinfo, dependfile)
-            end
-        end)}
-end
-
--- build module file for jobgraph
-function make_module_jobgraph(target, jobgraph, opt)
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
-    local dryrun = option.get("dry-run")
-
-    local jobname = target:fullname() .. "/module/" .. (name or opt.cppfile)
-    jobgraph:add(jobname, function(index, total, jobopt)
-        local mapped_bmi
-        if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-            mapped_bmi = get_from_target_mapper(target, name).bmi
-        end
-
-        local build, dependinfo
-        local dependfile = target:dependfile(bmifile or opt.objectfile)
-        if provide or support.has_module_extension(opt.cppfile) then
-            build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-
-            -- needed to detect rebuild of dependencies
-            if provide and build then
-                mark_build(target, name)
-            end
-        end
-
-        -- append requires flags
-        if opt.module.requires then
-            _append_requires_flags(target, opt.module, name, opt.cppfile, bmifile, opt)
-        end
-
-        -- for cpp file we need to check after appendings the flags
-        if build == nil then
-            build, dependinfo = should_build(target, opt.cppfile, bmifile, {name = name, objectfile = opt.objectfile, requires = opt.module.requires})
-        end
-
-        if build then
-            -- compile if it's a named module
-            if provide or support.has_module_extension(opt.cppfile) then
-                if not dryrun then
-                    local objectdir = path.directory(opt.objectfile)
-                    if not os.isdir(objectdir) then
-                        os.mkdir(objectdir)
-                    end
-                end
-
-                local fileconfig = target:fileconfig(opt.cppfile)
-                local public = fileconfig and fileconfig.public
-                local external = fileconfig and fileconfig.external
-                local from_moduleonly = external and external.moduleonly
-                local bmifile = mapped_bmi or bmifile
-                if external and not from_moduleonly then
-                    if not mapped_bmi then
-                        progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                        _compile_bmi_step(target, bmifile, opt.cppfile, opt.objectfile, provide)
-                    end
-                else
-                    progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-                    _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, provide)
-                end
+            if module.interface or module.implementation then
+                progress.show(opt.progress, "compiling.$(mode) %s", module.sourcefile)
+                _compile_objectfile_step(target, module)
             else
-                os.tryrm(opt.objectfile) -- force rebuild for .cpp files
+                os.tryrm(module.objectfile) -- force rebuild for .cpp files
             end
-            depend.save(dependinfo, dependfile)
         end
-    end)
+    end
 end
 
 -- build module file for batchcmds
-function make_module_buildcmds(target, batchcmds, opt)
+function make_module_buildcmds(target, batchcmds, module, opt)
 
-    local name, provide, _ = support.get_provided_module(opt.module)
-    local bmifile = provide and support.get_bmi_path(provide.bmi)
+    -- generate and append module mapper file
+    local build = should_build(target, module)
+    local bmi = opt and opt.bmi
+    local objectfile = opt and opt.objectfile
 
-    local mapped_bmi
-    if provide and support.memcache():get2(target:fullname() .. name, "reuse") then
-        mapped_bmi = get_from_target_mapper(target, name).bmi
-    end
-
-    -- append requires flags
-    if opt.module.requires then
-        _append_requires_flags(target, opt.module, name, opt.cppfile, bmifile, opt)
-    end
-
-    -- compile if it's a named module
-    if provide or support.has_module_extension(opt.cppfile) then
-        batchcmds:mkdir(path.directory(opt.objectfile))
-
-        local fileconfig = target:fileconfig(opt.cppfile)
-        local public = fileconfig and fileconfig.public
-        local external = fileconfig and fileconfig.external
-        local from_moduleonly = external and external.moduleonly
-        local bmifile = mapped_bmi or bmifile
-        if external and not from_moduleonly then
-            if not mapped_bmi then
-                batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.bmi.$(mode) %s", target:fullname(), name or opt.cppfile)
-                _compile_bmi_step(target, bmifile, opt.cppfile, provide, {batchcmds = batchcmds})
-            end
-        else
-            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), name or opt.cppfile)
-            _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, provide, {batchcmds = batchcmds})
+    if build then
+        local objectdir = path.directory(module.objectfile)
+        batchcmds:mkdir(objectdir)
+        if module.bmifile then
+            local bmidir = path.directory(module.bmifile)
+            batchcmds:mkdir(bmidir)
         end
-    else
-        batchcmds:rm(opt.objectfile) -- force rebuild for .cpp files
+        if bmi and objectfile then
+            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:fullname(), module.name)
+            _compile_one_step(target, module, {batchcmds = batchcmds})
+        elseif bmi then
+            batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.bmi.$(mode) %s", target:fullname(), module.name)
+            _compile_bmi_step(target, module, {batchcmds = batchcmds})
+        else
+            if module.interface or module.implementation then
+                batchcmds:show_progress(opt.progress, "compiling.$(mode) %s", module.sourcefile)
+                _compile_objectfile_step(target, module, {batchcmds = batchcmds})
+            else
+                batchcmds:rm(module.objectfile) -- force rebuild for .cpp files
+            end
+        end
     end
-    batchcmds:add_depfiles(opt.cppfile)
-    return os.mtime(opt.objectfile)
+    batchcmds:add_depfiles(module.sourcefile)
+    return os.mtime(module.objectfile)
 end
 
--- build headerunit file for batchjobs
-function make_headerunit_buildjobs(target, job_name, batchjobs, headerunit, bmifile, outputdir, opt)
-    local already_exists = add_headerunit_to_target_mapper(target, headerunit, bmifile)
-    if not already_exists then
-        return {
-            name = job_name,
-            sourcefile = headerunit.path,
-            job = batchjobs:newjob(job_name, function(index, total, jobopt)
-                if not os.isdir(outputdir) then
-                    os.mkdir(outputdir)
-                end
+-- build headerunit file for batchjobs / jobgraph
+function make_headerunit_job(target, headerunit, opt)
 
-                local compinst = compiler.load("cxx", {target = target})
-                local compflags = compinst:compflags({sourcefile = headerunit.path, target = target})
-
-                local dependfile = target:dependfile(bmifile)
-                local dependinfo = depend.load(dependfile) or {}
-                dependinfo.files = {}
-                local depvalues = {compinst:program(), compflags}
-
-                local name = headerunit.unique and headerunit.name or headerunit.path
-
-                if opt.build then
-                    progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), headerunit.name)
-                    _compile(target, _make_headerunitflags(target, headerunit, bmifile), name, target:objectfile(headerunit.path), true)
-                end
-
-                table.insert(dependinfo.files, headerunit.path)
-                dependinfo.values = depvalues
-                depend.save(dependinfo, dependfile)
-            end)}
-    end
-end
-
--- build headerunit file for jobgraph
-function make_headerunit_jobgraph(target, job_name, jobgraph, headerunit, bmifile, outputdir, opt)
-    local already_exists = add_headerunit_to_target_mapper(target, headerunit, bmifile)
-    if not already_exists then
-        jobgraph:add(job_name, function(index, total, jobopt)
-            if not os.isdir(outputdir) then
-                os.mkdir(outputdir)
-            end
-
-            local compinst = compiler.load("cxx", {target = target})
-            local compflags = compinst:compflags({sourcefile = headerunit.path, target = target})
-
-            local dependfile = target:dependfile(bmifile)
-            local dependinfo = depend.load(dependfile) or {}
-            dependinfo.files = {}
-            local depvalues = {compinst:program(), compflags}
-
-            local name = headerunit.unique and headerunit.name or headerunit.path
-
-            if opt.build then
-                progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), headerunit.name)
-                _compile(target, _make_headerunitflags(target, headerunit, bmifile), name, target:objectfile(headerunit.path), true)
-            end
-
-            table.insert(dependinfo.files, headerunit.path)
-            dependinfo.values = depvalues
-            depend.save(dependinfo, dependfile)
-        end)
+    local build = should_build(target, headerunit)
+    if build then
+        local name = headerunit.unique and path.filename(headerunit.name) or headerunit.name
+        local headertype = (headerunit.method == "include-angle") and ":angle" or ":quote"
+        progress.show(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), name)
+        _compile(target, _make_headerunitflags(target, headerunit, headertype), (headertype == ":angle") and headerunit.name or headerunit.sourcefile)
     end
 end
 
 -- build headerunit file for batchcmds
-function make_headerunit_buildcmds(target, batchcmds, headerunit, bmifile, outputdir, opt)
-    batchcmds:mkdir(outputdir)
-    add_headerunit_to_target_mapper(target, headerunit, bmifile)
+function make_headerunit_buildcmds(target, batchcmds, headerunit, opt)
+    
+    local compinst = compiler.load("cxx", {target = target})
+    local compflags = compinst:compflags({sourcefile = headerunit.sourcefile, target = target, sourcekind = "cxx"})
+    local depvalues = {compinst:program(), compflags}
 
-    if opt.build then
-        local name = headerunit.unique and headerunit.name or headerunit.path
+    local build = should_build(target, headerunit)
+    if build then
+        local name = headerunit.unique and path.filename(headerunit.name) or headerunit.name
+        local headertype = (headerunit.method == "include-angle") and ":angle" or ":quote"
         batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.headerunit.$(mode) %s", target:fullname(), name)
-        _batchcmds_compile(batchcmds, target, _make_headerunitflags(target, headerunit, bmifile), target:objectfile(headerunit.path))
+        _batchcmds_compile(batchcmds, target, _make_headerunitflags(target, headerunit, headertype), (headertype == ":angle") and headerunit.name or headerunit.sourcefile)
+        batchcmds:add_depfiles(headerunit.sourcefile)
     end
-    batchcmds:add_depfiles(headerunit.path)
-    return os.mtime(bmifile)
+    batchcmds:add_depvalues(depvalues)
 end

--- a/xmake/rules/c++/modules/msvc/support.lua
+++ b/xmake/rules/c++/modules/msvc/support.lua
@@ -27,9 +27,6 @@ import(".support", {inherit = true})
 -- load module support for the current target
 function load(target)
 
-    local msvc = target:toolchain("msvc")
-    local vcvars = msvc:config("vcvars")
-
     -- enable std modules if c++23 by defaults
     if target:data("c++.msvc.enable_std_import") == nil and target:policy("build.c++.modules.std") then
         local languages = target:get("languages")
@@ -56,19 +53,18 @@ function load(target)
     end
 end
 
--- strip flags that doesn't affect bmi generation
-function strip_flags(target, flags)
+-- flags that doesn't affect bmi generation
+function strippeable_flags()
+
     -- speculative list as there is no resource that list flags that prevent reusability, this list will likely be improve over time
     -- @see https://learn.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=msvc-170
-    local strippable_flags = {
-        "I",
+    local strippeable_flags = {
         "TP",
         "errorReport",
         "W",
         "w",
         "sourceDependencies",
         "scanDependencies",
-        "reference",
         "PD",
         "nologo",
         "MP",
@@ -76,10 +72,8 @@ function strip_flags(target, flags)
         "interface",
         "ifcOutput",
         "help",
-        "headerUnit",
         "headerName",
         "Fp",
-        "Fo",
         "Fm",
         "Fe",
         "Fd",
@@ -94,28 +88,18 @@ function strip_flags(target, flags)
         "analyze",
         "?",
     }
-    if not target:policy("build.c++.modules.tryreuse.discriminate_on_defines") then
-        table.join2(strippable_flags, {"D", "U"})
-    end
-    local output = {}
-    for _, flag in ipairs(flags) do
-        local strip = false
-        for _, _flag in ipairs(strippable_flags) do
-            if flag:startswith("cl::-" .. _flag) or flag:startswith("cl::/" .. _flag) or
-               flag:startswith("-" .. _flag) or flag:startswith("/" .. _flag) then
-                strip = true
-                break
-            end
-        end
-        if not strip then
-            table.insert(output, flag)
-        end
-    end
-    return output
+    local splitted_strippeable_flags = {
+        "Fo",
+        "I",
+        "reference",
+        "headerUnit",
+    }
+    return strippeable_flags, splitted_strippeable_flags
 end
 
 -- provide toolchain include dir for stl headerunit when p1689 is not supported
 function toolchain_includedirs(target)
+
     for _, toolchain_inst in ipairs(target:toolchains()) do
         if toolchain_inst:name() == "msvc" then
             local vcvars = toolchain_inst:config("vcvars")
@@ -128,20 +112,24 @@ function toolchain_includedirs(target)
     raise("msvc toolchain includedirs not found!")
 end
 
+function has_two_phase_compilation_support(_)
+    return false
+end
+
 -- build c++23 standard modules if needed
 function get_stdmodules(target)
+
     if target:policy("build.c++.modules.std") then
-        if target:data("c++.msvc.enable_std_import") then
-            local msvc = target:toolchain("msvc")
-            if msvc then
-                local vcvars = msvc:config("vcvars")
-                if vcvars.VCInstallDir and vcvars.VCToolsVersion then
-                    modules = {}
+        local msvc = target:toolchain("msvc")
+        if msvc then
+            local vcvars = msvc:config("vcvars")
+            if vcvars.VCInstallDir and vcvars.VCToolsVersion then
+                modules = {}
 
-                    local stdmodulesdir = path.join(vcvars.VCInstallDir, "Tools", "MSVC", vcvars.VCToolsVersion, "modules")
-                    assert(stdmodulesdir, "Can't enable C++23 std modules, directory missing !")
+                local stdmodulesdir = path.join(vcvars.VCInstallDir, "Tools", "MSVC", vcvars.VCToolsVersion, "modules")
 
-                    return {path.join(stdmodulesdir, "std.ixx"), path.join(stdmodulesdir, "std.compat.ixx")}
+                if os.isdir(stdmodulesdir) then
+                    return {path.normalize(path.join(stdmodulesdir, "std.ixx")), path.normalize(path.join(stdmodulesdir, "std.compat.ixx"))}
                 end
             end
         end
@@ -154,6 +142,7 @@ function get_bmi_extension()
 end
 
 function get_ifcoutputflag(target)
+
     local ifcoutputflag = _g.ifcoutputflag
     if ifcoutputflag == nil then
         local compinst = target:compiler("cxx")
@@ -167,6 +156,7 @@ function get_ifcoutputflag(target)
 end
 
 function get_ifconlyflag(target)
+
     local ifconlyflag = _g.ifconlyflag
     if ifconlyflag == nil then
         local compinst = target:compiler("cxx")
@@ -178,20 +168,8 @@ function get_ifconlyflag(target)
     return ifconlyflag or nil
 end
 
-function get_ifcsearchdirflag(target)
-    local ifcsearchdirflag = _g.ifcsearchdirflag
-    if ifcsearchdirflag == nil then
-        local compinst = target:compiler("cxx")
-        if compinst:has_flags({"-ifcSearchDir", os.tmpdir()}, "cxxflags", {flagskey = "cl_ifc_search_dir"})  then
-            ifcsearchdirflag = "-ifcSearchDir"
-        end
-        assert(ifcsearchdirflag, "compiler(msvc): does not support c++ module flag(/ifcSearchDir)!")
-        _g.ifcsearchdirflag = ifcsearchdirflag or false
-    end
-    return ifcsearchdirflag or nil
-end
-
 function get_interfaceflag(target)
+
     local interfaceflag = _g.interfaceflag
     if interfaceflag == nil then
         local compinst = target:compiler("cxx")
@@ -205,6 +183,7 @@ function get_interfaceflag(target)
 end
 
 function get_referenceflag(target)
+
     local referenceflag = _g.referenceflag
     if referenceflag == nil then
         local compinst = target:compiler("cxx")
@@ -218,6 +197,7 @@ function get_referenceflag(target)
 end
 
 function get_headernameflag(target)
+
     local headernameflag = _g.headernameflag
     if headernameflag == nil then
         local compinst = target:compiler("cxx")
@@ -231,6 +211,7 @@ function get_headernameflag(target)
 end
 
 function get_headerunitflag(target)
+
     local headerunitflag = _g.headerunitflag
     if headerunitflag == nil then
         local compinst = target:compiler("cxx")
@@ -245,6 +226,7 @@ function get_headerunitflag(target)
 end
 
 function get_exportheaderflag(target)
+
     local exportheaderflag = _g.exportheaderflag
     if exportheaderflag == nil then
         if get_headernameflag(target) then
@@ -256,6 +238,7 @@ function get_exportheaderflag(target)
 end
 
 function get_scandependenciesflag(target)
+
     local scandependenciesflag = _g.scandependenciesflag
     if scandependenciesflag == nil then
         local compinst = target:compiler("cxx")
@@ -278,6 +261,7 @@ function get_scandependenciesflag(target)
 end
 
 function get_cppversionflag(target)
+
     local cppversionflag = _g.cppversionflag
     if cppversionflag == nil then
         local compinst = target:compiler("cxx")
@@ -288,6 +272,7 @@ function get_cppversionflag(target)
 end
 
 function get_internalpartitionflag(target)
+
     local internalpartitionflag = _g.internalpartitionflag
     if internalpartitionflag == nil then
         local compinst = target:compiler("cxx")

--- a/xmake/rules/c++/modules/scanner.lua
+++ b/xmake/rules/c++/modules/scanner.lua
@@ -25,28 +25,15 @@ import("core.base.graph")
 import("core.base.option")
 import("async.runjobs")
 import("support")
+import("mapper")
 import("stlheaders")
 
 function _scanner(target)
-    local cachekey = tostring(target)
-    local scanner = support.memcache():get2("scanner", cachekey)
-    if scanner == nil then
-        if target:has_tool("cxx", "clang", "clangxx", "clang_cl") then
-            scanner = import("clang.scanner", {anonymous = true})
-        elseif target:has_tool("cxx", "gcc", "gxx") then
-            scanner = import("gcc.scanner", {anonymous = true})
-        elseif target:has_tool("cxx", "cl") then
-            scanner = import("msvc.scanner", {anonymous = true})
-        else
-            local _, toolname = target:tool("cxx")
-            raise("compiler(%s): does not support c++ module!", toolname)
-        end
-        support.memcache():set2("scanner", cachekey, scanner)
-    end
-    return scanner
+    return support.import_implementation_of(target, "scanner")
 end
 
-function _parse_meta_info(target, metafile)
+function _parse_meta_info(metafile)
+
     local metadata = json.loadfile(metafile)
     if metadata.file and metadata.name then
         return metadata.file, metadata.name, metadata
@@ -75,6 +62,16 @@ function _parse_meta_info(target, metafile)
     return filename, name, metadata
 end
 
+function _get_headerunit_bmifile(target, headerfile)
+    local outputdir = support.get_outputdir(target, headerfile, {headerunit = true})
+    return path.join(outputdir, path.filename(headerfile) .. support.get_bmi_extension(target))
+end
+
+function _bmifile_for(target, module)
+    local bmifile = support.get_bmi_path(path.filename(module.name) .. support.get_bmi_extension(target))
+    return path.join(support.get_outputdir(target, module.sourcefile, {interface = module.interface, headerunit = module.headerunit}), bmifile)
+end
+
 -- parse module dependency data
 --[[
 {
@@ -88,7 +85,7 @@ end
     },
     provides = {
       hello = {
-        bmi = "build/.gens/stl_headerunit/linux/x86_64/release/rules/modules/cache/hello.gcm",
+        bmifile = "build/.gens/stl_headerunit/linux/x86_64/release/rules/modules/cache/hello.gcm",
         sourcefile = "src/hello.mpp"
       }
     }
@@ -104,97 +101,125 @@ end
   }
 }]]
 function _parse_dependencies_data(target, moduleinfos)
+
+    -- insert headerunit as moduleinfos
+    local headerunitinfos = {}
+    for _, moduleinfo in ipairs(moduleinfos) do
+        assert(moduleinfo.version <= 1)
+        for _, rule in ipairs(moduleinfo.rules) do
+            for _, dep in ipairs(rule.requires) do
+                local method = dep["lookup-method"] or "by-name"
+                if method:startswith("include") then
+                    local sourcefile = dep["source-path"]
+                    table.insert(headerunitinfos, {
+                        version = 0,
+                        revision = 0,
+                        sourcefile = path.normalize(sourcefile),
+                        rules = {{
+                            provides = {table.join(dep, {["is-headerunit"] = true})}
+                        }}
+                    })
+                end
+            end
+        end
+    end
+    table.join2(moduleinfos, headerunitinfos)
+
     local modules
+    local modules_names = hashset.new()
     for _, moduleinfo in ipairs(moduleinfos) do
         assert(moduleinfo.version <= 1)
         for _, rule in ipairs(moduleinfo.rules) do
             modules = modules or {}
-            local m = {}
-            if rule.provides then
-                for _, provide in ipairs(rule.provides) do
-                    m.provides = m.provides or {}
-                    assert(provide["logical-name"])
-                    local bmifile = provide["compiled-module-path"]
-                    -- try to find the compiled module path in outputs filed (MSVC doesn't generate compiled-module-path)
-                    if not bmifile then
-                        for _, output in ipairs(rule.outputs) do
-                            if output:endswith(support.get_bmi_extension(target)) then
-                                bmifile = output
-                                break
-                            end
-                        end
+            local module = {objectfile = path.translate(rule["primary-output"]), sourcefile = moduleinfo.sourcefile}
+            -- local reused, from = support.is_reused(moduleinfo.target or target, module.sourcefile)
+            -- local _target = reused and from or target
+            -- if moduleinfo.target then
+            --     _target = moduleinfo.target
+            -- end
 
-                        -- we didn't found the compiled module path, so we assume it
-                        if not bmifile then
-                            local name = provide["logical-name"] .. support.get_bmi_extension(target)
-                            -- partition ":" character is invalid path character on windows
-                            -- @see https://github.com/xmake-io/xmake/issues/2954
-                            name = name:replace(":", "-")
-                            bmifile = path.join(support.get_outputdir(target,  name), name)
-                        end
+            if rule.provides then
+                -- assume rule.provides is always one element on C++
+                -- @see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1689r5.html
+                local provide = rule.provides and rule.provides[1]
+                if provide then
+                    assert(provide["logical-name"])
+
+                    module.name = provide["logical-name"]
+                    module.sourcefile = module.sourcefile or path.normalize(provide["source-path"])
+                    modules_names:insert(module.name)
+                    module.headerunit = provide["is-headerunit"]
+                    module.interface = (not module.headerunit and provide["is-interface"] == nil) and true or provide["is-interface"]
+                    module.implementation = not module.interface and not module.headerunit
+                    module.method = provide["lookup-method"] or "by-name"
+
+                    if module.headerunit then
+                        local key = support.get_headerunit_key(target, module.sourcefile)
+                        module.key = key
                     end
-                    m.provides[provide["logical-name"]] = {
-                        bmi = bmifile,
-                        sourcefile = moduleinfo.sourcefile,
-                        interface = provide["is-interface"]
+
+                    -- XMake handle bmifile so we don't need rely on compiler-module-path
+                    module.bmifile = _bmifile_for(target, module)
+                end
+            end
+
+            if rule.requires then
+                module.deps = {}
+                for _, dep in ipairs(rule.requires) do
+                    local method = dep["lookup-method"] or "by-name"
+                    local name = dep["logical-name"]
+                    local headerunit = method:startswith("include")
+                    local key = headerunit and support.get_headerunit_key(target, name)
+                    module.deps[name] = {
+                        name = name,
+                        method = method,
+                        headerunit = headerunit,
+                        key = key,
+                        unique = dep["unique-on-source-path"] or false,
                     }
                 end
-            else
-                m.cppfile = moduleinfo.sourcefile
             end
-            assert(rule["primary-output"])
-            modules[path.translate(rule["primary-output"])] = m
-        end
-    end
-
-    for _, moduleinfo in ipairs(moduleinfos) do
-        for _, rule in ipairs(moduleinfo.rules) do
-            local m = modules[path.translate(rule["primary-output"])]
-            for _, r in ipairs(rule.requires) do
-                m.requires = m.requires or {}
-                local p = r["source-path"]
-                if not p then
-                    for _, dependency in pairs(modules) do
-                        if dependency.provides and dependency.provides[r["logical-name"]] then
-                            p = dependency.provides[r["logical-name"]].bmi
-                            break
-                        end
-                    end
+            if module.headerunit then
+                local key = module.sourcefile .. module.key
+                if not modules[key] then
+                    modules[key] = table.clone(module)
+                    modules[key].name = module.sourcefile
                 end
-                m.requires[r["logical-name"]] = {
-                    method = r["lookup-method"] or "by-name",
-                    path = p and path.translate(p) or nil,
-                    unique = r["unique-on-source-path"] or false
-                }
+                local name = module.name .. module.key
+                modules[name] = module
+                modules[name].alias = true
+            else
+                modules[module.sourcefile] = module
             end
         end
     end
-    return modules
+    return modules, modules_names
 end
 
 -- generate edges for DAG
-function _get_edges(nodes, modules)
+function _get_edges(target, nodes, modules)
+
   local edges = {}
-  local module_names = {}
   local name_filemap = {}
-  local named_module_names = hashset.new()
+  local deps_names = hashset.new()
   for _, node in ipairs(table.unique(nodes)) do
       local module = modules[node]
-      local module_name, _, cppfile = support.get_provided_module(module)
-      if module_name then
-          if named_module_names:has(module_name) then
-              raise("duplicate module name detected \"" .. module_name .. "\"\n    -> " .. cppfile .. "\n    -> " .. name_filemap[module_name])
+      if module.interface or module.implementation then
+          if deps_names:has(module.name) then
+              raise("duplicate module name detected for \"" .. module.name .. "\"\n  <" .. target:fullname() .. "> -> " .. module.sourcefile .. "\n  <" .. target:fullname() .. "> -> " .. name_filemap[module.name])
           end
-          named_module_names:insert(module_name)
-          name_filemap[module_name] = cppfile
+          deps_names:insert(module.name)
+          name_filemap[module.name] = module.sourcefile
+      elseif module.headerunit then
+          deps_names:insert(module.name)
+          name_filemap[module.name] = module.sourcefile
       end
-      if module.requires then
-          for required_name, _ in table.orderpairs(module.requires) do
-              for _, required_node in ipairs(nodes) do
-                  local name, _, _ = support.get_provided_module(modules[required_node])
-                  if name and name == required_name then
-                      table.insert(edges, {required_node, node})
-                  end
+      for dep_name, _ in table.orderpairs(module.deps) do
+          for _, dep_node in ipairs(nodes) do
+              local dep_module = modules[dep_node]
+              if (dep_module.interface or dep_module.implementation or dep_module.headerunit) and dep_name == dep_module.name then
+                  table.insert(edges, {dep_node, node})
+                  break
               end
           end
       end
@@ -202,78 +227,307 @@ function _get_edges(nodes, modules)
   return edges
 end
 
-function _get_package_modules(target, package)
+-- get package modules
+function _get_package_modules(target, package, opt)
+
+    opt = opt or {}
     local package_modules
     local modulesdir = path.join(package:installdir(), "modules")
     local metafiles = os.files(path.join(modulesdir, "*", "*.meta-info"))
     for _, metafile in ipairs(metafiles) do
         package_modules = package_modules or {}
-        local modulefile, name, metadata = _parse_meta_info(target, metafile)
-        local moduleonly = not package:libraryfiles()
-        package_modules[name] = {file = path.join(modulesdir, modulefile), metadata = metadata, external = {moduleonly = moduleonly}}
+        local modulefile, _, metadata = _parse_meta_info(metafile)
+
+        local bmionly = package:libraryfiles() and true or false
+        package_modules[path.join(modulesdir, modulefile)] = {defines = metadata.defines,
+                                                              undefines = metadata.undefines,
+                                                              bmionly = bmionly,
+                                                              external = opt.external and target:fullname()}
     end
     return package_modules
 end
 
--- generate module dependencies
-function generate_module_dependencies(target, jobgraph, sourcebatch, opt)
-    local parsejob = target:fullname() .. "/parse_module_dependencies"
-    jobgraph:add(parsejob, function (index, total, opt)
-        local changed = support.memcache():get2("modules", "dependencies_changed")
-        if changed then
-            local cachekey = target:fullname() .. "/" .. sourcebatch.rulename
-            local moduleinfos = support.load_moduleinfos(target, sourcebatch)
-            local modules = _parse_dependencies_data(target, moduleinfos)
-            support.localcache():set2("modules", cachekey, modules)
-            support.localcache():save()
-        end
-    end)
-    for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
-        local jobname = target:fullname() .. "/generate_module_dependencies/" .. sourcefile
-        jobgraph:add(jobname, function (index, total, opt)
-            local changed = _scanner(target).generate_dependency_for(target, sourcefile, opt)
-            if changed then
-                support.memcache():set2("modules", "dependencies_changed", true)
-            end
-        end)
-        jobgraph:add_orders(jobname, parsejob)
+function _get_packages_for(target)
+    local packages = {}
+    for pkgname, pkg in pairs(target:orderpkgs()) do
+        packages[pkgname] = {pkg = pkg, external = false}
     end
+    for _, dep in pairs(target:orderdeps()) do
+        local dep_packages = _get_packages_for(dep)
+        for pkgname, package in pairs(dep_packages) do
+            packages[pkgname] = {pkg = package.pkg, external = package.external or dep}
+        end
+    end
+    return packages
 end
 
--- get module dependencies
-function get_module_dependencies(target, sourcebatch)
-    local cachekey = target:fullname() .. "/" .. sourcebatch.rulename
-    local modules = support.localcache():get2("modules", cachekey)
-    assert(modules, "no module dependencies!")
-    return modules
+-- get packages modules
+function _get_packages_modules(target)
+
+    -- parse all meta-info and append their informations to the package store
+    local packages_modules = support.memcache():get2(target:fullname(), "cxx_packages_modules")
+    if not packages_modules then
+        packages_modules = {}
+        local packages = _get_packages_for(target)
+        for _, package in table.orderpairs(packages) do
+            local package_modules = _get_package_modules(package.external or target, package.pkg, {external = package.external})
+            if package_modules then
+               packages_modules = packages_modules or {}
+               table.join2(packages_modules, package_modules)
+            end
+        end
+        support.memcache():set2(target:fullname(), "cxx_packages_modules", packages_modules)
+    end
+    return packages_modules
 end
 
--- get headerunits info
-function get_headerunits(target, sourcebatch, modules)
-    local headerunits
-    local stl_headerunits
-    for _, objectfile in ipairs(sourcebatch.objectfiles) do
-        local m = modules[objectfile]
-        if m then
-            for name, r in pairs(m.requires) do
-                if r.method ~= "by-name" then
-                    local unittype = r.method == "include-angle" and ":angle" or ":quote"
-                    if stlheaders.is_stlheader(name) then
-                        stl_headerunits = stl_headerunits or {}
-                        if not table.find_if(stl_headerunits, function(i, v) return v.name == name end) then
-                            table.insert(stl_headerunits, {name = name, path = r.path, type = unittype, unique = r.unique})
-                        end
-                    else
-                        headerunits = headerunits or {}
-                        if not table.find_if(headerunits, function(i, v) return v.name == name end) then
-                            table.insert(headerunits, {name = name, path = r.path, type = unittype, unique = r.unique})
-                        end
+-- get target deps modules
+function _get_targetdeps_modules(target)
+
+    local _, stdmodules_set = support.get_stdmodules(target)
+    local modules
+    for _, dep in ipairs(target:orderdeps()) do
+        local sourcebatch = dep:sourcebatches()["c++.build.modules.builder"]
+        if sourcebatch and sourcebatch.sourcefiles then
+            for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+                modules = modules or {}
+                if support.is_public(dep, sourcefile) or stdmodules_set:has(sourcefile) then
+                    local _fileconfig = dep:fileconfig(sourcefile)
+                    local fileconfig = {}
+                    if _fileconfig then
+                        fileconfig.defines = _fileconfig.defines
+                        fileconfig.undefines = _fileconfig.undefines
+                        fileconfig.includedirs = _fileconfig.includedirs
+                    end
+                    fileconfig.defines = table.join(fileconfig.defines or {}, dep:get("defines") or {})
+                    fileconfig.undefines = table.join(fileconfig.undefines or {}, dep:get("undefines") or {})
+                    fileconfig.includedirs = table.join(fileconfig.includedirs or {}, dep:get("includedirs") or {})
+                    if not dep:is_phony() then
+                        fileconfig.external = dep:fullname()
+                        fileconfig.bmionly = not dep:is_moduleonly()
+                    end
+                    if not modules[sourcefile] then
+                        modules[sourcefile] = fileconfig
                     end
                 end
             end
         end
     end
-    return headerunits, stl_headerunits
+    return modules
+end
+
+-- check if flags are compatible for module reuse
+function _are_flags_compatible(target, other, sourcefile)
+
+    local compinst1 = target:compiler("cxx")
+    local flags1 = compinst1:compflags({sourcefile = sourcefile, target = target, sourcekind = "cxx"})
+
+    local compinst2 = other:compiler("cxx")
+    local flags2 = compinst2:compflags({sourcefile = sourcefile, target = other, sourcekind = "cxx"})
+
+    local strip_defines = not target:policy("build.c++.modules.reuse.strict") and
+                                   not target:policy("build.c++.modules.tryreuse.discriminate_on_defines")
+
+    -- strip unrelevent flags
+    flags1 = support.strip_flags(target, flags1, {strip_defines = strip_defines})
+    flags2 = support.strip_flags(target, flags2, {strip_defines = strip_defines})
+
+    if #flags1 ~= #flags2 then
+        return false
+    end
+
+    table.sort(flags1)
+    table.sort(flags2)
+
+    for i = 1, #flags1 do
+        if flags1[i] ~= flags2[i] then
+            return false
+        end
+    end
+    return true
+end
+
+-- patch sourcebatch
+function _patch_sourcebatch(target, sourcebatch)
+
+    -- target deps modules
+    local depsmodules = _get_targetdeps_modules(target) or {}
+
+    -- package modules
+    local pkgmodules = _get_packages_modules(target) or {}
+
+    -- insert std package and deps modules, try to reused them if possible
+    local reuse = target:policy("build.c++.modules.reuse") or
+                  target:policy("build.c++.modules.tryreuse")
+    for sourcefile, fileconfig in pairs(table.join(depsmodules, pkgmodules)) do
+        if reuse and fileconfig.external then
+            local nocheck = target:policy("build.c++.modules.reuse.nocheck")
+            local strict = target:policy("build.c++.modules.reuse.strict") or
+                           target:policy("build.c++.modules.tryreuse.discriminate_on_defines")
+            local dep = target:dep(fileconfig.external)
+
+            local can_reuse = nocheck or _are_flags_compatible(target, dep, sourcefile, {strict = strict})
+            if can_reuse then
+                support.set_reused(target, dep, sourcefile)
+                if dep:is_moduleonly() then
+                    dep:data_set("cxx.modules.reused", true)
+                end
+            end
+        end
+        table.insert(sourcebatch.sourcefiles, sourcefile)
+        target:fileconfig_add(sourcefile, fileconfig)
+    end
+
+    sourcebatch.sourcekind = "cxx"
+    sourcebatch.objectfiles = {}
+    sourcebatch.dependfiles = {}
+    for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+        local reused, from = support.is_reused(target, sourcefile)
+        local _target = reused and from or target
+        local objectfile = _target:objectfile(sourcefile)
+        local dependfile = _target:dependfile(sourcefile or objectfile)
+        table.insert(sourcebatch.dependfiles, dependfile)
+    end
+end
+
+function _do_parse(target, sourcebatch)
+
+    local changed = support.memcache():get2(target:fullname(), "modules.changed")
+    if changed then
+        local moduleinfos = support.load_moduleinfos(target, sourcebatch)
+        local modules = _parse_dependencies_data(target, moduleinfos)
+        local localcache = support.localcache()
+
+        mapper.feed(target, modules, sourcebatch.sourcefiles)
+
+        -- check if a dependency is missing
+        local modules_names = hashset.from(table.keys(mapper.get_mapper_for(target)))
+        for _, module in pairs(modules) do
+            for dep_name, dep in pairs(module.deps) do
+                if dep.method == "by-name" then
+                    if not modules_names:has(dep_name) then
+                        if option.get("diagnosis") then
+                            print("parsing:", target:fullname(), "\nmodules:", modules or {}, "\nmoduleinfos:", moduleinfos or {})
+                        end
+                        raise("<%s> missing %s dependency for module %s", target:fullname(), dep_name, module.name or module.sourcefile)
+                    end
+                end
+            end
+        end
+        localcache:set2(target:fullname(), "c++.modules", modules)
+        localcache:save()
+    end
+
+    -- steal from c++.build sourcebatch named modules
+    local cxx_sourcebatch = target:sourcebatches()["c++.build"]
+    if cxx_sourcebatch then
+        cxx_sourcebatch.sourcefiles = {}
+        cxx_sourcebatch.dependfiles = {}
+        for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+            local module = mapper.get(target, sourcefile)
+            if not module.interface and not module.implementation then
+                table.insert(cxx_sourcebatch.sourcefiles, sourcefile)
+                local objectfile = target:objectfile(sourcefile)
+                table.insert(cxx_sourcebatch.dependfiles, target:dependfile(objectfile))
+            end
+        end
+    end
+
+    -- sort modules
+    sort_modules_by_dependencies(target, get_modules(target), {jobgraph = target:policy("build.jobgraph")})
+end
+
+function _do_scan(target, sourcefile, opt)
+    local changed = _scanner(target).scan_dependency_for(target, sourcefile, opt)
+    if changed or not support.localcache():get2(target:fullname(), "module_mapper") then
+        support.memcache():set2(target:fullname(), "modules.changed", true)
+    end
+end
+
+-- scan module dependencies
+function _schedule_module_dependencies_scan(target, jobgraph, sourcebatch)
+
+    function get_basegroup_for(target)
+        return target:fullname() .. "/modules"
+    end
+    function get_parsejob_for(target)
+        return get_basegroup_for(target) .. "/parse"
+    end
+    function get_scangroup_for(target)
+        return get_basegroup_for(target) .. "/scan"
+    end
+    function get_scanfilejob_for(target, sourcefile)
+        return get_scangroup_for(target) .. "/" .. sourcefile
+    end
+    
+    local parsejob = get_parsejob_for(target)
+    jobgraph:add(parsejob, function()
+        _do_parse(target, sourcebatch)
+    end)
+
+    local scangroup = get_scangroup_for(target)
+    local has_scanjob = false
+    jobgraph:group(scangroup, function()
+        for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+            local reused, _ = support.is_reused(target, sourcefile)
+            if not reused then
+                local scanfilejob = get_scanfilejob_for(target, sourcefile)
+
+                if not jobgraph:has(scanfilejob) then
+                    has_scanjob = true
+                    jobgraph:add(scanfilejob, function(_, _, opt)
+                        _do_scan(target, sourcefile, opt)
+                    end)
+                end
+            end
+        end
+    end)
+    if has_scanjob then
+        jobgraph:add_orders(scangroup, parsejob)
+    end
+    local memcache = support.memcache()
+    local jobdeps = memcache:get2(target:fullname(), "jobdeps")
+    if jobdeps then
+        -- insert parent scangroup as dependency for parsejob
+        for _, parsedep in ipairs(jobdeps.parsedeps) do
+            if jobgraph:has(parsedep) then
+                jobgraph:add_orders(parsejob, parsedep)
+            end
+        end
+    end
+
+    for _, dep in ipairs(target:orderdeps()) do
+        local dep_parsejob = get_parsejob_for(dep)
+        if jobgraph:has(dep_parsejob) then
+            jobgraph:add_orders(dep_parsejob, parsejob)
+        else
+            jobdeps = memcache:get2(dep:fullname(), "jobdeps")
+            if not jobdeps then
+                jobdeps = {}
+            end
+            jobdeps.parsedeps = jobdeps.parsedeps or {}
+            table.insert(jobdeps.parsedeps, parsejob)
+            memcache:set2(dep:fullname(), "jobdeps", jobdeps)
+        end
+    end
+end
+
+-- get headerunits info
+function sort_headerunits(target, headerunits)
+
+    local _headerunits
+    local stl_headerunits
+    for _, headerunit in ipairs(headerunits) do
+        local module = mapper.get(target, headerunit)
+        if stlheaders.is_stlheader(path.filename(module.name)) then
+            stl_headerunits = stl_headerunits or {}
+            table.insert(stl_headerunits, headerunit)
+        else
+            _headerunits = _headerunits or {}
+            table.insert(_headerunits, headerunit)
+        end
+    end
+    return _headerunits, stl_headerunits
 end
 
 -- https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1689r5.html
@@ -306,6 +560,7 @@ end
   ]
 }]]
 function fallback_generate_dependencies(target, jsonfile, sourcefile, preprocess_file)
+
     local output = {version = 1, revision = 0, rules = {}}
     local rule = {outputs = {jsonfile}}
     rule["primary-output"] = target:objectfile(sourcefile)
@@ -349,7 +604,7 @@ function fallback_generate_dependencies(target, jsonfile, sourcefile, preprocess
                 module_depname = module_depname:sub(2, -2)
                 module_dep["lookup-method"] = "include-quote"
                 module_dep["unique-on-source-path"] = true
-                module_dep["source-path"] = support.find_quote_header_file(target, sourcefile, module_depname)
+                module_dep["source-path"] = support.find_quote_header_file(sourcefile, module_depname)
             elseif module_depname:startswith("<") then
                 module_depname = module_depname:sub(2, -2)
                 module_dep["lookup-method"] = "include-angle"
@@ -364,7 +619,7 @@ function fallback_generate_dependencies(target, jsonfile, sourcefile, preprocess
     end
 
     if module_name_export or internal then
-        local outputdir = support.get_outputdir(target, sourcefile)
+        local outputdir = support.get_outputdir(target, sourcefile, {scan = true})
 
         local provide = {}
         provide["logical-name"] = module_name_export or module_name_private
@@ -382,135 +637,150 @@ function fallback_generate_dependencies(target, jsonfile, sourcefile, preprocess
     io.writefile(jsonfile, jsondata)
 end
 
--- extract packages modules dependencies
-function get_all_packages_modules(target)
-
-    -- parse all meta-info and append their informations to the package store
-    local packages = target:pkgs() or {}
-    for _, deps in ipairs(target:orderdeps()) do
-        table.join2(packages, deps:pkgs())
-    end
-
-    local packages_modules
-    for _, package in table.orderpairs(packages) do
-        local package_modules = _get_package_modules(target, package)
-        if package_modules then
-           packages_modules = packages_modules or {}
-           table.join2(packages_modules, package_modules)
-        end
-    end
-    return packages_modules
-end
-
 -- topological sort
-function sort_modules_by_dependencies(target, objectfiles, modules, opt)
-    local build_objectfiles = {}
-    local link_objectfiles = {}
-    local edges = _get_edges(objectfiles, modules)
-    local dag = graph.new(true)
-    for _, e in ipairs(edges) do
-        dag:add_edge(e[1], e[2])
-    end
-    local objectfiles_sorted, has_cycle = dag:topo_sort()
-    if has_cycle then
-        local cycle = dag:find_cycle()
-        if cycle then
-            local names = {}
-            for _, objectfile in ipairs(cycle) do
-                local name, _, cppfile = support.get_provided_module(modules[objectfile])
-                table.insert(names, name or cppfile)
+function sort_modules_by_dependencies(target, modules, opt)
+
+    local changed = support.memcache():get2(target:fullname(), "modules.changed")
+    if changed then
+        local built_modules = {}
+        local built_headerunits = {}
+        local objectfiles = {}
+
+        -- feed the dag
+        local nodes = {}
+        for node, module in pairs(modules) do
+            table.insert(nodes, module.headerunit and node or module.sourcefile)
+        end
+        -- table.unique(nodes)
+        local edges = _get_edges(target, nodes, modules)
+        local dag = graph.new(true)
+        for _, e in ipairs(edges) do
+            dag:add_edge(e[1], e[2])
+        end
+        -- check if dag have dependency cycles
+        local has_cycle = dag:find_cycle()
+        if has_cycle then
+            local cycle = dag:find_cycle()
+            if cycle then
+                local names = {}
+                for _, sourcefile in ipairs(cycle) do
+                    local module = modules[sourcefile]
+                    table.insert(names, module.name or module.sourcefile)
+                end
+                local module = modules[cycle[1]]
+                table.insert(names, module.name or module.sourcefile)
+                raise("circular modules dependency detected!\n%s", table.concat(names, "\n   -> import "))
             end
-            local name, _, cppfile = support.get_provided_module(modules[cycle[1]])
-            table.insert(names, name or cppfile)
-            raise("circular modules dependency detected!\n%s", table.concat(names, "\n   -> import "))
         end
-    end
-    objectfiles_sorted = table.reverse(objectfiles_sorted)
-    local objectfiles_sorted_set = hashset.from(objectfiles_sorted)
-    for _, objectfile in ipairs(objectfiles) do
-        if not objectfiles_sorted_set:has(objectfile) then
-            table.insert(objectfiles_sorted, objectfile)
-            objectfiles_sorted_set:insert(objectfile)
+        -- sort sourcefiles by dependencies
+        local sourcefiles_sorted = dag:topological_sort()
+        local sourcefiles_sorted_set = hashset.from(sourcefiles_sorted)
+        for sourcefile, _ in pairs(modules) do
+            if not sourcefiles_sorted_set:has(sourcefile) then
+                table.insert(sourcefiles_sorted, sourcefile)
+                sourcefiles_sorted_set:insert(sourcefile)
+            end
         end
-    end
-    local culleds
-    for _, objectfile in ipairs(objectfiles_sorted) do
-        local name, provide, cppfile = support.get_provided_module(modules[objectfile])
-        local fileconfig = target:fileconfig(cppfile)
-        local public
-        local external
-        local can_cull = true
-        if fileconfig then
-            public = fileconfig.public
-            external = fileconfig.external
-            can_cull = fileconfig.cull == nil and true or fileconfig.cull
-        end
-        can_cull = can_cull and target:policy("build.c++.modules.culling")
-        local insert = true
-        if provide then
-            insert = public or (not external or external.moduleonly)
-            if insert and not public and can_cull then
-                insert = false
-                local edges = dag:adjacent_edges(objectfile)
-                local public = fileconfig and fileconfig.public
-                if edges then
-                    for _, edge in ipairs(edges) do
-                        if edge:to() ~= objectfile and objectfiles_sorted_set:has(edge:to()) then
-                            insert = true
-                            break
+        -- prepare objectfiles list built by the target
+        local culleds
+        for _, sourcefile in ipairs(sourcefiles_sorted) do
+            local module = mapper.get(target, sourcefile)
+            local is_named = module.interface or module.implementation or module.headerunit
+            local sort = (is_named and module.sourcealias) or (module.headerunit and not module.alias) or (not is_named)
+            if sort then
+                local insert = false
+                local name
+                local reused, from = support.is_reused(target, sourcefile)
+
+                if module.name and not module.headerunit then -- named modules
+                    name = module.name
+
+                    insert = not support.can_be_culled(target, sourcefile)
+
+                    -- if module is cullable (culling policy enabled and not a public module), try to cull
+                    if not insert then
+                        local edges = dag:adjacent_edges(sourcefile)
+                        if edges then
+                            for _, edge in ipairs(edges) do
+                                if edge:to() ~= sourcefile and sourcefiles_sorted_set:has(edge:to()) then
+                                    insert = true
+                                    break
+                                end
+                            end
                         end
                     end
+                else -- regular translation unit with import statements, always inserted
+                    insert = true
+                end
+
+                if insert then
+                    if reused then
+                        if from:is_moduleonly() or module.name == "std" or module.name == "std.compat" then
+                            local objectfile = from:objectfile(sourcefile)
+                            table.insert(objectfiles, tostring(objectfile))
+                        end
+                    elseif module.headerunit then
+                        table.insert(built_headerunits, sourcefile)
+                    else
+                        table.insert(built_modules, sourcefile)
+                        -- insert objectfile if module is not imported from a static / shared library and if has a custom extension (not .cpp)
+                        -- if not so objectfile will be handled by c++.build rule
+                        if not support.is_bmionly(target, sourcefile) then
+                            local objectfile = target:objectfile(sourcefile)
+                            table.insert(objectfiles, tostring(objectfile))
+                        end
+                   end
+                elseif support.is_external(target, sourcefile) or module.headerunit or name == "std" or name == "std.compat" then
+                else
+                    sourcefiles_sorted_set:remove(sourcefile)
+                    culleds = culleds or {}
+                    culleds[target:fullname()] = culleds[target:fullname()] or {}
+                    table.insert(culleds[target:fullname()], format("%s -> %s", name, sourcefile))
                 end
             end
         end
-        if insert then
-            table.insert(build_objectfiles, objectfile)
-            table.insert(link_objectfiles, objectfile)
-        elseif external and not external.from_moduleonly then
-            table.insert(build_objectfiles, objectfile)
-        else
-            objectfiles_sorted_set:remove(objectfile)
-            if name ~= "std" and name ~= "std.compat" then
-                culleds = culleds or {}
-                culleds[target:fullname()] = culleds[target:fullname()] or {}
-                table.insert(culleds[target:fullname()], format("%s -> %s", name, cppfile))
-            end
-        end
-    end
 
-    if culleds then
-        if option.get("verbose") then
-            local culled_strs = {}
-            for target_name, m in pairs(culleds) do
-                table.insert(culled_strs, format("%s:\n        %s", target_name, table.concat(m, "\n        ")))
-            end
-            wprint("some modules have got culled, because it is not consumed by its target nor flagged as a public module with add_files(\"xxx.mpp\", {public = true})\n    %s",
-                   table.concat(culled_strs, "\n    "))
-        else
-            wprint("some modules have got culled, use verbose (-v) mode to more informations")
-        end
-    end
-
-    return build_objectfiles, link_objectfiles
-end
-
--- get source modulefile for external target deps
-function get_targetdeps_modules(target)
-    local sourcefiles
-    for _, dep in ipairs(target:orderdeps()) do
-        local sourcebatch = dep:sourcebatches()["c++.build.modules.builder"]
-        if sourcebatch and sourcebatch.sourcefiles then
-            for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
-                local fileconfig = dep:fileconfig(sourcefile)
-                local public = (fileconfig and fileconfig.public and not fileconfig.external) or false
-                if public then
-                    sourcefiles = sourcefiles or {}
-                    table.insert(sourcefiles, sourcefile)
-                    target:fileconfig_add(sourcefile, {external = {moduleonly = dep:is_moduleonly()}})
+        -- if some named modules has been culled, notify the user
+        if culleds then
+            if option.get("verbose") then
+                local culled_strs = {}
+                for target_name, m in pairs(culleds) do
+                    table.insert(culled_strs, format("%s:\n        %s", target_name, table.concat(m, "\n        ")))
                 end
+                wprint("some modules have got culled, because it is not consumed by its target nor flagged as a public module with add_files(\"xxx.mpp\", {public = true})\n    %s",
+                       table.concat(culled_strs, "\n    "))
+            else
+                wprint("some modules have got culled, use verbose (-v) mode to more informations")
             end
         end
+        table.sort(objectfiles)
+        built_headerunits = table.unique(built_headerunits)
+
+        support.localcache():set2(target:fullname(), "c++.modules.built_artifacts", {modules = built_modules, headerunits = built_headerunits, objectfiles = objectfiles})
+        support.localcache():save()
+        support.memcache():set2(target:fullname(), "modules.changed", false)
     end
-    return sourcefiles
+    local built_artifacts = support.localcache():get2(target:fullname(), "c++.modules.built_artifacts")
+    return built_artifacts.modules, built_artifacts.headerunits, built_artifacts.objectfiles
 end
 
+function get_modules(target)
+    local modules = support.localcache():get2(target:fullname(), "c++.modules")
+    assert(modules, "no modules!")
+    return modules
+end
+
+function after_scan(target)
+    if target:data("cxx.has_modules") and not target:is_moduleonly() then
+        local sourcebatch = target:sourcebatches()["c++.build.modules.builder"]
+        local _, _, objectfiles = sort_modules_by_dependencies(target, modules, {jobgraph = target:policy("build.jobgraph")})
+        sourcebatch.objectfiles = objectfiles
+    end
+end
+
+function main(target, jobgraph, sourcebatch)
+    if target:data("cxx.has_modules") then
+        _patch_sourcebatch(target, sourcebatch)
+        _schedule_module_dependencies_scan(target, jobgraph, sourcebatch)
+    end
+end

--- a/xmake/rules/c++/modules/stlheaders.lua
+++ b/xmake/rules/c++/modules/stlheaders.lua
@@ -23,6 +23,7 @@ import("core.base.hashset")
 
 -- the stl headers list
 function _stlheaders()
+
     return {
     "algorithm",
     "forward_list",

--- a/xmake/rules/c++/precompiled_header/xmake.lua
+++ b/xmake/rules/c++/precompiled_header/xmake.lua
@@ -27,7 +27,7 @@ rule("c.build.pcheader")
     end, {jobgraph = true})
 
 rule("c++.build.pcheader")
-    add_orders("c++.build.pcheader", "c++.build.modules.builder")
+    add_orders("c++.build.modules.scanner", "c++.build.pcheader", "c++.build.modules.builder")
     on_config(function (target, opt)
         import("private.action.build.pcheader").config(target, "cxx", opt)
     end)

--- a/xmake/toolchains/msvc/check.lua
+++ b/xmake/toolchains/msvc/check.lua
@@ -128,7 +128,7 @@ function _check_vc_build_tools(toolchain, sdkdir)
     end
 end
 
-function main(toolchain)
+function main(toolchain, opt)
 
     -- only for windows or linux (msvc-wine)
     if not is_host("windows", "linux") then
@@ -141,7 +141,7 @@ function main(toolchain)
     local mrc = path.basename(config.get("mrc") or "rc"):lower()
     if cc == "cl" or cxx == "cl" or mrc == "rc" then
         local sdkdir = toolchain:sdkdir()
-        if sdkdir then
+        if not opt.ignore_sdk and sdkdir then
             return _check_vc_build_tools(toolchain, sdkdir)
         else
             -- find it from packages


### PR DESCRIPTION
- improve general stability
- cleanup code
- disable build.fence and enable full parallelization
- support clang two phase compilation and add policy to toggle it `build.c++.modules.two_phases`
- deprecate policies (for naming consistency):
    1. `build.c++.modules.tryreuse`, introduce `build.c++.modules.reuse` instead
    2. `build.c++.modules.tryreuse.discriminate_on_defines`, introduce `build.c++.modules.reuse.strict` instead
    3. `build.c++.gcc/clang/msvc.fallbackscanner`, introduce `build.c++.modules.gcc/clang/msvc.fallbackscanner` instead
    4. `build.c++.gcc.modules.cxx11abi`, introduce `build.c++.modules.gcc.cxx11abi` instead
- improve module build artifact reutilisation and introduce `build.c++.modules.reuse.nocheck` to force reutilisation without checking flags
- add new tests
- modules now use their original target defines / undefines (should partially fixes https://github.com/xmake-io/xmake/issues/6028#issuecomment-2615893336)
- fix --sdk= when using llvm toolchain on windows with msstl std module